### PR TITLE
Replace hardcoded text with Language.GetTextValue()

### DIFF
--- a/Items/Armor/DesertProwler/DesertProwlerSet.cs
+++ b/Items/Armor/DesertProwler/DesertProwlerSet.cs
@@ -15,6 +15,7 @@ using Terraria.Audio;
 using Terraria.DataStructures;
 using CalamityMod.Dusts;
 using ReLogic.Utilities;
+using Terraria.Localization;
 
 namespace CalamityMod.Items.Armor.DesertProwler
 {
@@ -166,7 +167,7 @@ namespace CalamityMod.Items.Armor.DesertProwler
 
                 if (setBonusIndex != -1)
                 {
-                    string dir = Main.ReversedUpDownArmorSetBonuses ? "UP" : "DOWN";
+                    string dir = Language.GetTextValue(Main.ReversedUpDownArmorSetBonuses ? "Key.UP" : "Key.DOWN");
                     TooltipLine setBonus1 = new TooltipLine(item.Mod, "CalamityMod:SetBonus1", CalamityUtils.GetTextFromModItem<DesertProwlerHat>("AbilityBrief").Format(dir));
                     setBonus1.OverrideColor = Color.Lerp(new Color(255, 229, 156), new Color(233, 225, 198), 0.5f + 0.5f * (float)Math.Sin(Main.GlobalTimeWrappedHourly * 3f));
                     tooltips.Insert(setBonusIndex + 1, setBonus1);

--- a/Items/Armor/Wulfrum/WulfrumSet.cs
+++ b/Items/Armor/Wulfrum/WulfrumSet.cs
@@ -10,6 +10,7 @@ using CalamityMod.Cooldowns;
 using Terraria.Audio;
 using System;
 using System.Collections.Generic;
+using Terraria.Localization;
 using static Microsoft.Xna.Framework.Input.Keys;
 using static Terraria.ModLoader.ModContent;
 
@@ -228,7 +229,7 @@ namespace CalamityMod.Items.Armor.Wulfrum
 
                 if (setBonusIndex != -1)
                 {
-                    string dir = Main.ReversedUpDownArmorSetBonuses ? "UP" : "DOWN";
+                    string dir = Language.GetTextValue(Main.ReversedUpDownArmorSetBonuses ? "Key.UP" : "Key.DOWN");
                     TooltipLine setBonus1 = new TooltipLine(item.Mod, "CalamityMod:SetBonus1", CalamityUtils.GetTextFromModItem<WulfrumHat>("AbilityBrief").Format(dir));
                     setBonus1.OverrideColor = Color.Lerp(new Color(194, 255, 67), new Color(112, 244, 244), 0.5f + 0.5f * (float)Math.Sin(Main.GlobalTimeWrappedHourly * 3f));
                     tooltips.Insert(setBonusIndex + 1, setBonus1);


### PR DESCRIPTION
This PR replace hardcoded strings with the usage of Language.GetTextValue().

The shift from hardcoded text to the use of localization keys aims to mitigate potential inconveniences for mod translators, including myself.