### PR TITLE
Localize vanilla armor setbonus

### DIFF
--- a/Items/CalamityGlobalItem.cs
+++ b/Items/CalamityGlobalItem.cs
@@ -946,8 +946,7 @@ namespace CalamityMod.Items
 
             if (set == "CrystalAssassin")
             {
-                player.setBonus = "Allows the ability to dash\n" +
-                    "10% increased damage and critical strike chance";
+                player.setBonus = CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.CrystalAssassin");
                 modPlayer.DashID = string.Empty;
             }
             else if (set == "SquireTier2")
@@ -955,20 +954,19 @@ namespace CalamityMod.Items
                 player.lifeRegen += 3;
                 player.GetDamage<SummonDamageClass>() += 0.15f;
                 player.GetCritChance<MeleeDamageClass>() += 10;
-                player.setBonus += "\nIncreases your life regeneration\n" +
-                            "15% increased minion damage and 10% increased melee critical strike chance";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.SquireTier2")}";
             }
             else if (set == "HuntressTier2")
             {
                 player.GetDamage<SummonDamageClass>() += 0.1f;
                 player.GetDamage<RangedDamageClass>() += 0.1f;
-                player.setBonus += "\n10% increased minion and ranged damage";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.HuntressTier2")}";
             }
             else if (set == "ApprenticeTier2")
             {
                 player.GetDamage<SummonDamageClass>() += 0.05f;
                 player.GetCritChance<MagicDamageClass>() += 15;
-                player.setBonus += "\n5% increased minion damage and 15% increased magic critical strike chance";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.ApprenticeTier2")}";
             }
             else if (set == "MonkTier3")
             {
@@ -976,34 +974,31 @@ namespace CalamityMod.Items
                 player.GetAttackSpeed<MeleeDamageClass>() += 0.1f;
                 player.GetDamage<MeleeDamageClass>() += 0.1f;
                 player.GetCritChance<MeleeDamageClass>() += 10;
-                player.setBonus += "\n10% increased melee damage, melee critical strike chance and melee speed\n" +
-                            "30% increased minion damage";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.MonkTier3")}";
             }
             else if (set == "SquireTier3")
             {
                 player.lifeRegen += 6;
                 player.GetDamage<SummonDamageClass>() += 0.1f;
                 player.GetCritChance<MeleeDamageClass>() += 10;
-                player.setBonus += "\nMassively increased life regeneration\n" +
-                            "10% increased minion damage and melee critical strike chance";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.SquireTier3")}";
             }
             else if (set == "HuntressTier3")
             {
                 player.GetDamage<SummonDamageClass>() += 0.1f;
                 player.GetDamage<RangedDamageClass>() += 0.1f;
-                player.setBonus += "\n10% increased minion and ranged damage";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.HuntressTier3")}";
             }
             else if (set == "ApprenticeTier3")
             {
                 player.GetDamage<SummonDamageClass>() += 0.1f;
                 player.GetCritChance<MagicDamageClass>() += 15;
-                player.setBonus += "\n10% increased minion damage and 15% increased magic critical strike chance";
+                player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.ApprenticeTier3")}";
             }
             else if (set == "SpectreHealing")
             {
                 player.GetDamage<MagicDamageClass>() += 0.2f;
-                player.setBonus = "Reduces Magic damage by 20% and converts it to healing force\n" +
-                    "Magic damage done to enemies heals the player with lowest health";
+                player.setBonus = CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.SpectreHealing");
             }
             else if (set == "SolarFlare")
             {

--- a/Items/VanillaArmorChanges/AdamantiteArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/AdamantiteArmorSetChange.cs
@@ -30,11 +30,13 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText = setBonusText.Replace("20% increased melee and movement speed", "15% increased melee speed and 20% increased movement speed");
-            setBonusText += "\nHalf of your current DR is added to your critical strike chance\n" +
-                $"Continuously doing damage makes you gradually gain more and more defense, up to a maximum of {DefenseBoostMax}\n" +
-                "When not doing damage, this bonus gradually decays\n" +
-                "This added defense can be broken by defense damage";
+            Player player = Main.LocalPlayer;
+            if (player.armor[0].type == ItemID.AdamantiteHelmet)
+            {
+                setBonusText = CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}.Melee");
+            }
+            
+            setBonusText += $"\n{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(DefenseBoostMax)}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/ChlorophyteArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/ChlorophyteArmorSetChange.cs
@@ -24,11 +24,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText = $"Summons a powerful leaf crystal to shoot pulses of life every {PulseReleaseRate / 60f} seconds\n" +
-                $"The pulses do a base damage of {BaseDamageToEnemies} to enemies within its range\n" +
-                $"The pulses also provide a {AmountToHealPerPulse} health boost to you and all players on your team\n" +
-                $"Players healed by pulses cannot be healed by another pulse until {DelayBetweenHeals / 60f} seconds have passed\n" +
-                "Both the health boost and the damage scale based on your strongest class";
+            setBonusText = $"{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(PulseReleaseRate / 60f, BaseDamageToEnemies, AmountToHealPerPulse, DelayBetweenHeals / 60f)}";
         }
     }
 }

--- a/Items/VanillaArmorChanges/CobaltArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/CobaltArmorSetChange.cs
@@ -30,9 +30,13 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText = setBonusText.Replace("15", "10");
-            setBonusText += $"\n{SpeedBoostSetBonusPercentage}% increased max speed and acceleration\n" +
-                $"You gain a damage and critical strike chance boost relative to your current movement speed, up to {SpeedBoostSetBonusPercentage}%";
+            Player player = Main.LocalPlayer;
+            if (player.armor[0].type == ItemID.CobaltHelmet)
+            {
+                setBonusText = CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}.Melee");
+            }
+            
+            setBonusText += $"\n{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(SpeedBoostSetBonusPercentage)}";
         }
 
         public static float CalculateMovementSpeedInterpolant(Player player)

--- a/Items/VanillaArmorChanges/CopperArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/CopperArmorSetChange.cs
@@ -28,9 +28,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nIncreases all damage by 2");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/EskimoArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/EskimoArmorSetChange.cs
@@ -20,16 +20,11 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override int[] AlternativeLegPieceIDs => new int[] { ItemID.PinkEskimoPants };
 
-        public override bool NeedsToCreateSetBonusTextManually => true;
-
         public override string ArmorSetName => "Eskimo";
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            // Not sure why it doesn't say Set bonus automatically
-            setBonusText = "Set bonus: Multiplies all cold-based debuff damage by 1.25\n" +
-                "Cold enemies will deal reduced contact damage to the player\n" +
-                "Provides immunity to the Chilled, Frozen, Frostburn and Glacial State debuffs";
+            setBonusText = $"{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/FrostArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/FrostArmorSetChange.cs
@@ -22,9 +22,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
         public override void UpdateSetBonusText(ref string setBonusText)
         {   
             int PercentBoost = (int)Math.Round(ProximityBoost * 100);
-            setBonusText = "Melee and ranged attacks inflict Frostbite\n" +
-                $"{PercentBoost}% increased damage which scales based on how far the target is from you\n" +
-                "Closer range grants melee damage, while farther range grants ranged damage";
+            setBonusText = $"{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(PercentBoost)}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/GladiatorArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/GladiatorArmorSetChange.cs
@@ -20,9 +20,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText += "\n+3 defense\n" +
-                        "+60 maximum stealth\n" +
-                        "5% increased rogue damage and 10% increased velocity";
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyHeadPieceEffect(Player player)

--- a/Items/VanillaArmorChanges/GoldArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/GoldArmorSetChange.cs
@@ -32,9 +32,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nAll enemies have a 4% chance to drop 1 gold. All bosses killed drop 3 gold\nYou gain 1% critical strike chance for every 5 gold in your inventory, capped at 10%");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/IronArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/IronArmorSetChange.cs
@@ -28,9 +28,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nIncreases damage reduction by 6%\n+1 HP/s life regen");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/LeadArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/LeadArmorSetChange.cs
@@ -26,9 +26,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nIncreases damage reduction by 3%\n+0.5 HP/s life regen\nGrants immunity to knockback");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/MeteorArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/MeteorArmorSetChange.cs
@@ -16,7 +16,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
         // Meteor Armor only makes space gun cost 50% instead of zero mana.
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText = setBonusText.Replace("0", "50%");
+            setBonusText = $"{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/MiningArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/MiningArmorSetChange.cs
@@ -21,7 +21,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText += "\nMining ore will sometimes have additional yield";
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/MoltenArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/MoltenArmorSetChange.cs
@@ -17,8 +17,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            string extraLine = "\n20% extra true melee damage\nGrants immunity to fire blocks and temporary immunity to lava";
-            setBonusText += extraLine;
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/MonkT2ArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/MonkT2ArmorSetChange.cs
@@ -16,8 +16,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText += "\n10% increased melee speed, crit, and damage\n" +
-                        "15% increased minion damage";
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyHeadPieceEffect(Player player)

--- a/Items/VanillaArmorChanges/MythrilArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/MythrilArmorSetChange.cs
@@ -24,8 +24,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText += "\nEnemy hits release mythril flares, which home in on enemies after a short delay\n" +
-                $"Once a flare is created, there is a {FlareFrameSpawnDelay} frame delay before another one can appear";
+            setBonusText += $"\n{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(FlareFrameSpawnDelay)}";
         }
 
         public override void ApplyHeadPieceEffect(Player player)

--- a/Items/VanillaArmorChanges/NecroArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/NecroArmorSetChange.cs
@@ -22,9 +22,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            string extraLines = "\nAllows you to temporarily survive fatal damage\n" +
-                $"Grants up to {PostMortemDuration} seconds of life before imminent death";
-            setBonusText += extraLines;
+            setBonusText += $"\n{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(PostMortemDuration)}";
         }
 
         public override void ApplyArmorSetBonus(Player player) => player.Calamity().necroSet = true;

--- a/Items/VanillaArmorChanges/ObsidianArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/ObsidianArmorSetChange.cs
@@ -13,13 +13,9 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override string ArmorSetName => "Obsidian";
 
-        public override bool NeedsToCreateSetBonusTextManually => true;
-
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            setBonusText = "Set Bonus: Increases whip range by 50% and speed by 35%\n" +
-                        "Increases minion damage by 15%\n" +
-                        "Grants immunity to fire blocks and temporary immunity to lava";
+            setBonusText = $"{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/PlatinumArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/PlatinumArmorSetChange.cs
@@ -31,9 +31,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nEvery 10 defense gives you +0.5 HP/s life regen, 1% increased damage and 1% increased critical strike chance\nThese effects cap at 40 defense");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/ShadowArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/ShadowArmorSetChange.cs
@@ -38,7 +38,10 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void ApplyLegPieceEffect(Player player) => ApplyAnyPieceEffect(player);
 
-        public override void UpdateSetBonusText(ref string setBonusText) => setBonusText = "Set bonus: 15% increased max movement speed and acceleration";
+        public override void UpdateSetBonusText(ref string setBonusText)
+        {
+            setBonusText = $"{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
+        }
 
         public override void ApplyArmorSetBonus(Player player)
         {

--- a/Items/VanillaArmorChanges/SilverArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/SilverArmorSetChange.cs
@@ -33,9 +33,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\n+0.5 HP/s life regen\nTwo seconds after getting hit for 20 or more damage, you heal for 10\nGetting hit again resets the timer, delaying the heal");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/TinArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/TinArmorSetChange.cs
@@ -28,9 +28,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public override void UpdateSetBonusText(ref string setBonusText)
         {
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nIncreases armor penetration by 5");
-            setBonusText += sb.ToString();
+            setBonusText += $"\n{CalamityUtils.GetTextValue($"Vanilla.Armor.SetBonus.{ArmorSetName}")}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/TungstenArmorSetChange.cs
+++ b/Items/VanillaArmorChanges/TungstenArmorSetChange.cs
@@ -34,16 +34,9 @@ namespace CalamityMod.Items.VanillaArmorChanges
             float kb = player.GetWeaponKnockback(player.ActiveItem());
             float bonus = MathHelper.Clamp(kb, 0f, MaxKnockbackCritConversion);
             
-            StringBuilder sb = new StringBuilder(256);
-            sb.Append("\nIncreases your critical strike chance by 100% of the knockback of your held weapon");
-            sb.Append("\nThis effect caps at Insane knockback, which gives 10% increased critical strike chance");
-            sb.Append("\nIncreases all knockback by 33%, this counts for the above boost");
-            sb.Append("\nCurrent bonus: ");
-            sb.Append(bonus.ToString("n2"));
-            sb.Append("% critical strike chance from ");
-            sb.Append(kb.ToString("n2"));
-            sb.Append(" knockback");
-            setBonusText += sb.ToString();
+            string bonusText = bonus.ToString("n2");
+            string kbText = kb.ToString("n2");
+            setBonusText += $"\n{CalamityUtils.GetText($"Vanilla.Armor.SetBonus.{ArmorSetName}").Format(bonusText, kbText)}";
         }
 
         public override void ApplyArmorSetBonus(Player player)

--- a/Items/VanillaArmorChanges/VanillaArmorChange.cs
+++ b/Items/VanillaArmorChanges/VanillaArmorChange.cs
@@ -22,7 +22,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
 
         public virtual string ArmorSetName => null;
 
-        public virtual bool NeedsToCreateSetBonusTextManually => false;
+        public virtual bool NeedsToCreateSetBonusTextManually => true;
 
         public virtual void UpdateSetBonusText(ref string setBonusText) { }
 

--- a/Items/VanillaArmorChanges/VanillaArmorChangeManager.cs
+++ b/Items/VanillaArmorChanges/VanillaArmorChangeManager.cs
@@ -36,7 +36,7 @@ namespace CalamityMod.Items.VanillaArmorChanges
                     ArmorChanges[i].AlternativeBodyPieceIDs.Contains(checkItem.type);
                 bool isValidLegPiece = (ArmorChanges[i].LegPieceID ?? ItemID.None) == checkItem.type ||
                     ArmorChanges[i].AlternativeLegPieceIDs.Contains(checkItem.type);
-                if (isValidHeadPiece || isValidBodyPiece || isValidLegPiece)
+                if ((isValidHeadPiece || isValidBodyPiece || isValidLegPiece) && !ArmorChanges[i].NeedsToCreateSetBonusTextManually)
                     ArmorChanges[i].UpdateSetBonusText(ref setBonusText);
             }
         }

--- a/Localization/en-US/Mods.CalamityMod.Vanilla.Armor.hjson
+++ b/Localization/en-US/Mods.CalamityMod.Vanilla.Armor.hjson
@@ -1,1 +1,143 @@
+SetBonus: {
+	Adamantite: {
+		$parentVal:
+			'''
+			Half of your current DR is added to your critical strike chance
+			Continuously doing damage makes you gradually gain more and more defense, up to a maximum of {0}
+			When not doing damage, this bonus gradually decays
+			This added defense can be broken by defense damage
+			'''
+		Melee: 15% increased melee speed and 20% increased movement speed
+	}
 
+	Chlorophyte:
+		'''
+		Summons a powerful leaf crystal to shoot pulses of life every {0} seconds
+		The pulses do a base damage of {1} to enemies within its range
+		The pulses also provide a {2} health boost to you and all players on your team
+		Players healed by pulses cannot be healed by another pulse until {3} seconds have passed
+		Both the health boost and the damage scale based on your strongest class
+		'''
+
+	Cobalt: {
+		$parentVal:
+			'''
+			{0}% increased max speed and acceleration
+			You gain a damage and critical strike chance boost relative to your current movement speed, up to {0}%
+			'''
+		Melee: 10% increased melee damage
+	}
+
+	Copper: Increases all damage by 2
+	Eskimo:
+		'''
+		Multiplies all cold-based debuff damage by 1.25
+		Cold enemies will deal reduced contact damage to the player
+		Provides immunity to the Chilled, Frozen, Frostburn and Glacial State debuffs
+		'''
+	Frost:
+		'''
+		Melee and ranged attacks inflict Frostbite
+		{0}% increased damage which scales based on how far the target is from you
+		Closer range grants melee damage, while farther range grants ranged damage
+		'''
+	Gladiator:
+		'''
+		+3 defense
+		+60 maximum stealth
+		5% increased rogue damage and 10% increased velocity
+		'''
+	Gold:
+		'''
+		All enemies have a 4% chance to drop 1 gold. All bosses killed drop 3 gold
+		You gain 1% critical strike chance for every 5 gold in your inventory, capped at 10%
+		'''
+	Iron:
+		'''
+		Increases damage reduction by 6%
+		+1 HP/s life regen
+		'''
+	Lead:
+		'''
+		Increases damage reduction by 3%
+		+0.5 HP/s life regen
+		Grants immunity to knockback
+		'''
+	Meteor: Space Gun costs 50% mana
+	Mining: Mining ore will sometimes have additional yield
+	Molten:
+		'''
+		20% extra true melee damage
+		Grants immunity to fire blocks and temporary immunity to lava
+		'''
+	MonkTier2:
+		'''
+		10% increased melee speed, crit, and damage
+		15% increased minion damage
+		'''
+	Mythril:
+		'''
+		Enemy hits release mythril flares, which home in on enemies after a short delay
+		Once a flare is created, there is a {0} frame delay before another one can appear
+		'''
+	Necro:
+		'''
+		Allows you to temporarily survive fatal damage
+		Grants up to {0} seconds of life before imminent death
+		'''
+	Obsidian:
+		'''
+		Increases whip range by 50% and speed by 35%
+		Increases minion damage by 15%
+		Grants immunity to fire blocks and temporary immunity to lava
+		'''
+	Platinum:
+		'''
+		Every 10 defense gives you +0.5 HP/s life regen, 1% increased damage and 1% increased critical strike chance
+		These effects cap at 40 defense
+		'''
+	Shadow: 15% increased max movement speed and acceleration
+	Silver:
+		'''
+		+0.5 HP/s life regen
+		Two seconds after getting hit for 20 or more damage, you heal for 10
+		Getting hit again resets the timer, delaying the heal
+		'''
+	Tin: Increases armor penetration by 5
+	Tungsten:
+		'''
+		Increases your critical strike chance by 100% of the knockback of your held weapon
+		This effect caps at Insane knockback, which gives 10% increased critical strike chance
+		Increases all knockback by 33%, this counts for the above boost
+		Current bonus: {0}% critical strike chance from {1} knockback
+		'''
+	CrystalAssassin:
+		'''
+		Allows the ability to dash
+		10% increased damage and critical strike chance
+		'''
+	SquireTier2:
+		'''
+		Increases your life regeneration
+		15% increased minion damage and 10% increased melee critical strike chance
+		'''
+	HuntressTier2: 10% increased minion and ranged damage
+	ApprenticeTier2: 5% increased minion damage and 15% increased magic critical strike chance
+	MonkTier3:
+		'''
+		10% increased melee damage, melee critical strike chance and melee speed
+		30% increased minion damage
+		'''
+	SquireTier3:
+		'''
+		Massively increased life regeneration
+		10% increased minion damage and melee critical strike chance
+		'''
+	HuntressTier3: 10% increased minion and ranged damage
+	ApprenticeTier3: 10% increased minion damage and 15% increased magic critical strike chance
+	SpectreHealing:
+		'''
+		Reduces Magic damage by 20% and converts it to healing force
+		Magic damage done to enemies heals the player with lowest health
+		'''
+}


### PR DESCRIPTION
- Implemented localization for the vanilla armor setbonus.
- Fixed a minor issue where the "Set bonus:" text was not automatically appended to the overall tooltip of the armor setbonus. This was due to an incorrect condition in the ApplySetBonusTooltipChanges method, specifically because the CreateTooltipManuallyAsNecessary method was not called in UpdateArmorSet hook. This was caused by the NeedsToCreateSetBonusTextManually property always being set to False.
- Removed the use of the `Replace` method. This approach has its drawbacks: if another mod overrides the setbonus tooltip, the `Replace` method may fail to locate the original text for replacement. Using this new approach provides a more flexible solution, beneficial for both devs and translators.