### PR TITLE
Fixed an error with lumenousAmulet inflicting riptide and not inflicting crush depth.

### DIFF
--- a/CalPlayer/CalamityPlayer.cs
+++ b/CalPlayer/CalamityPlayer.cs
@@ -1477,7 +1477,7 @@ namespace CalamityMod.CalPlayer
                 Player.statLifeMax2 += 45;
 
             int percentMaxLifeIncrease = 0;
-            if (ZoneAbyss && abyssalAmulet)
+            if (ZoneAbyss && (abyssalAmulet || lumenousAmulet))
                 percentMaxLifeIncrease += lumenousAmulet ? 25 : 10;
 
             // Blood Pact and Chalice of the Blood God stack their HP bonuses if you want to equip both

--- a/CalPlayer/CalamityPlayerOnHit.cs
+++ b/CalPlayer/CalamityPlayerOnHit.cs
@@ -1087,6 +1087,10 @@ namespace CalamityMod.CalPlayer
             {
                 CalamityUtils.Inflict246DebuffsNPC(target, BuffType<RiptideDebuff>());
             }
+            if (lumenousAmulet)
+            {
+                CalamityUtils.Inflict246DebuffsNPC(target, BuffType<CrushDepth>());
+            }
             if (alchFlask)
             {
                 CalamityUtils.Inflict246DebuffsNPC(target, BuffType<Plague>());

--- a/Items/Accessories/LumenousAmulet.cs
+++ b/Items/Accessories/LumenousAmulet.cs
@@ -24,7 +24,6 @@ namespace CalamityMod.Items.Accessories
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
             CalamityPlayer modPlayer = player.Calamity();
-            modPlayer.abyssalAmulet = true;
             modPlayer.lumenousAmulet = true;
             player.buffImmune[ModContent.BuffType<RiptideDebuff>()] = true;
             player.buffImmune[ModContent.BuffType<CrushDepth>()] = true;


### PR DESCRIPTION
-Added a check for the lumenousAmulet Bool in CalamityPlayerOnHit to inflict crush depth
-Removed setting abyssalAmulet to true in lumenousAmulet to prevent it from inflicting riptide
-Added an or statement in CalamityPlayer so the health bonus in abyss still takes effect, as this previously only checked for abyssalAmulet