### PR TITLE
Cache lava style at beginning of DrawWaters for performance

### DIFF
--- a/ILEditing/ILChangesLoading.cs
+++ b/ILEditing/ILChangesLoading.cs
@@ -45,6 +45,7 @@ namespace CalamityMod.ILEditing
             On_Main.DrawInfernoRings += DrawForegroundParticles;
             On_TileDrawing.DrawPartialLiquid += DrawCustomLava;
             On_WaterfallManager.DrawWaterfall_int_int_int_float_Vector2_Rectangle_Color_SpriteEffects += DrawCustomLavafalls;
+            On_Main.RenderWater += CacheLavaStyle;
             IL_LiquidRenderer.DrawNormalLiquids += ChangeWaterQuadColors;
             IL_Main.oldDrawWater += DrawCustomLava3;
             On_TileLightScanner.GetTileLight += MakeSulphSeaWaterBetter;


### PR DESCRIPTION
The custom lava styles of CalamityMod add a great deal of overhead when rendering lots of lava. This commit aims to optimize the process by caching the style at the beginning of the liquid drawing cycle.

Results:
I profiled both the original and updated methods in the same environment. 
![profile_old](https://github.com/CalamityTeam/CalamityModPublic/assets/51512085/28f62985-af50-441c-b29d-812221c27d66)
![profile_new](https://github.com/CalamityTeam/CalamityModPublic/assets/51512085/32a2c0fd-1bc6-44e0-bce4-2fc10d01d947)
