### PR TITLE
Fargo's Mutant Mod Stat Sheet support for the Rogue Class

### DIFF
--- a/ModSupport/WeakReferenceSupport.cs
+++ b/ModSupport/WeakReferenceSupport.cs
@@ -18,6 +18,7 @@ using CalamityMod.Items.Weapons.DraedonsArsenal;
 using CalamityMod.Items.Weapons.Magic;
 using CalamityMod.Items.Weapons.Ranged;
 using CalamityMod.Items.Weapons.Summon;
+using CalamityMod.Items.Weapons.Rogue;
 using CalamityMod.NPCs.AcidRain;
 using CalamityMod.NPCs.AquaticScourge;
 using CalamityMod.NPCs.Astral;
@@ -1039,6 +1040,17 @@ namespace CalamityMod
             Mod fargos = GetInstance<CalamityMod>().fargos;
             if (fargos is null)
                 return;
+
+            // Stat Sheet support
+            double Damage(DamageClass damageClass) => Math.Round(Main.LocalPlayer.GetTotalDamage(damageClass).Additive * Main.LocalPlayer.GetTotalDamage(damageClass).Multiplicative * 100 - 100);
+            int Crit(DamageClass damageClass) => (int)Main.LocalPlayer.GetTotalCritChance(damageClass);
+
+            int rogueItem = ModContent.ItemType<WulfrumKnife>(); 
+            DamageClass rogueDamageClass = ModContent.GetInstance<RogueDamageClass>();
+            Func<string> rogueDamage = () => $"Rogue Damage: {Damage(rogueDamageClass)}%";
+            Func<string> rogueCrit = () => $"Rogue Critical: {Crit(rogueDamageClass)}%";
+            fargos.Call("AddStat", rogueItem, rogueDamage);
+            fargos.Call("AddStat", rogueItem, rogueCrit);
 
             void AddToMutantShop(string bossName, string summonItemName, Func<bool> downed, int price)
             {


### PR DESCRIPTION
Adds rogue class support to the Stat Sheet UI from Fargo's Mutant Mod.
Fargo's Mutant Mod is a highly used mod together with Calamity, and there's already some modcall support for it.
This feature has been highly requested on Fargo's end, and it's much smoother for mods to implement support using the call system that exists purely for that purpose, than having the core mod explicitly supporting specific mods.
Won't need to be maintained, if any changes happen on Fargo's end we'll make sure it works with existing calls.

Currently uses the Wulfrum Knife for the stat icon, but change that however you wish. 
For reference, the vanilla classes use Copper weapons for icons.