### PR TITLE
Fix truffle worm bug

### DIFF
--- a/ILEditing/ILChangesLoading.cs
+++ b/ILEditing/ILChangesLoading.cs
@@ -151,6 +151,9 @@ namespace CalamityMod.ILEditing
             // Fix vanilla not accounting for spritebatch modification in held projectile drawing
             On_PlayerDrawLayers.DrawHeldProj += FixHeldProjectileBlendState;
 
+            // Fix vanilla not accounting for multiple bobbers when fishing with truffle worm
+            IL_Player.ItemCheck_CheckFishingBobbers += FixTruffleWormFishing;
+
             //Additional detours that are in their own item files given they are only relevant to these specific items:
             //Rover drive detours on Player.DrawInfernoRings to draw its shield
             //Wulfrum armor hooks on Player.KeyDoubleTap and DrawPendingMouseText to activate its set bonus and spoof the mouse text to display the stats of the activated weapon if shift is held


### PR DESCRIPTION
Sorry to be too late. I'm opening this PR for further discussion about a bugfix mentioned in [my previous PR](https://github.com/CalamityTeam/CalamityModPublic/pull/22).

In `Projectile.FishingCheck()`, if the first bait is truffle worm, it sets `localAI[1] = 1f`. Otherwise `localAI[1]` indicates the caught item. This becomes problematic for multiple bobbers (which Vanilla doesn't expect). The first bobber consumes truffle worm and spawns Duke Fishron, and every subsequent bobber which doesn't use truffle worm as a bait catches an iron pickaxe, because it has item ID `1`.

There can be various fixes to this bug. The way I came up with is preventing further bobbers to catch something when truffle worm was already used.