### PR TITLE
Made Bloody Worm Food and Teratoma only shimmerable after the respective boss is killed.

### DIFF
--- a/Items/SummonItems/BloodyWormFood.cs
+++ b/Items/SummonItems/BloodyWormFood.cs
@@ -50,11 +50,13 @@ namespace CalamityMod.Items.SummonItems
 
         public override void AddRecipes()
         {
+            Condition downedPerfs = new(CalamityUtils.GetText("Condition.DownedPerfs"), () => DownedBossSystem.downedPerforator);
             CreateRecipe().
                 AddIngredient(ItemID.CrimtaneBar, 3).
                 AddIngredient<BloodSample>(7).
                 AddIngredient(ItemID.Vertebrae, 13).
                 AddTile(TileID.DemonAltar).
+                AddDecraftCondition(downedPerfs).
                 Register();
         }
     }

--- a/Items/SummonItems/Teratoma.cs
+++ b/Items/SummonItems/Teratoma.cs
@@ -50,11 +50,13 @@ namespace CalamityMod.Items.SummonItems
 
         public override void AddRecipes()
         {
+            Condition downedHM = new(CalamityUtils.GetText("Condition.DownedHM"), () => DownedBossSystem.downedHiveMind);
             CreateRecipe().
                 AddIngredient(ItemID.DemoniteBar, 3).
                 AddIngredient<RottenMatter>(7).
                 AddIngredient(ItemID.RottenChunk, 13).
                 AddTile(TileID.DemonAltar).
+                AddDecraftCondition(downedHM).
                 Register();
         }
     }


### PR DESCRIPTION
This is done since their recipes include the material gotten only from the boss. This is unobtainable before the boss with Calamity Mod itself, but this change prevents unintended consequences from other mods' interventions.