### PR TITLE
Clowns now summon Chattering Teeth Bombs & Fixed Herpling AI bug

### DIFF
--- a/NPCs/CalamityGlobalNPC.cs
+++ b/NPCs/CalamityGlobalNPC.cs
@@ -3621,6 +3621,7 @@ namespace CalamityMod.NPCs
                             {
                                 case NPCID.Herpling:
                                 case NPCID.Derpling:
+                                case NPCID.ChatteringTeethBomb:
                                     return CalamityGlobalAI.BuffedHerplingAI(npc, Mod);
                             }
                         }


### PR DESCRIPTION
I was completing bestirary entries and noticed that Clowns don't summon Chattering Teeth Bombs. I took the logics from vanilla to amend it. Also, vanilla seems to have bug which makes Herplings not change direction from left to right when wet (right to left is possible).
`direction *= -direction;` is the problematic line, which is transferred to the buffed AI code as it is. I've changed it to `direction *= -1;`, but I'm not sure this is the right place to fix this.