### PR TITLE
Fix splitting worm bestiary bug

### DIFF
--- a/ILEditing/ILChangesLoading.cs
+++ b/ILEditing/ILChangesLoading.cs
@@ -147,6 +147,7 @@ namespace CalamityMod.ILEditing
 
             // Fix vanilla bugs exposed by Calamity mechanics
             IL_NPC.NPCLoot += FixSplittingWormBannerDrops;
+            On_NPC.PlayerInteraction += FixSplittingWormInteraction;
 
             // Fix vanilla not accounting for spritebatch modification in held projectile drawing
             On_PlayerDrawLayers.DrawHeldProj += FixHeldProjectileBlendState;

--- a/ILEditing/VanillaBugfixingILChanges.cs
+++ b/ILEditing/VanillaBugfixingILChanges.cs
@@ -46,6 +46,18 @@ namespace CalamityMod.ILEditing
         }
         #endregion Fixing Splitting Worm Banner Spam in Deathmode
 
+        #region Fixing Splitting Worm Interaction in Deathmode
+        // CONTEXT FOR FIX: In Death Mode, normal worms are capable of splitting similarly to the Eater of Worlds. This comes with problems with bestiary entries. The entries are incremented only when
+        // the killed npc is the head segment and it has been interacted at least once. These two conditions may be violated because NPC.NPCLoot only triggers once because of the above fix.
+        // The fix for former condition is in CalamityGlobalNPCLoot.OnKill. For the latter condition, NPC.PlayerInteraction should broadcast interaction to every other worm segments.
+        // This is already done for vanilla worm enemies like EOW.
+        private static void FixSplittingWormInteraction(On_NPC.orig_PlayerInteraction orig, NPC npc, int player)
+        {
+            orig(npc, player);
+            CalamityGlobalNPC.SplittingWormBroadcastInteractionWrapper(npc, player);
+        }
+        #endregion
+
         #region Fixing Vanilla Not Accounting For Spritebatch Modification in Held Projectiles
         private static bool HasLoggedHeldProjectileBlendStateCatch = false;
         private void FixHeldProjectileBlendState(On_PlayerDrawLayers.orig_DrawHeldProj orig, PlayerDrawSet drawinfo, Projectile proj)

--- a/NPCs/CalamityGlobalNPCLoot.cs
+++ b/NPCs/CalamityGlobalNPCLoot.cs
@@ -1737,6 +1737,10 @@ namespace CalamityMod.NPCs
             if (CalamityWorld.death && !SplittingWormLootBlockWrapper(npc, Mod))
                 DropHelper.BlockEverything();
 
+            // Correctly increment bestiary entries for splitting worms
+            if (npc.AnyInteractions())
+                SplittingWormBestiaryUpdate(npc);
+
             // Check whether bosses should be spawned naturally as a result of this NPC's death.
             CheckBossSpawn(npc);
 
@@ -2003,6 +2007,70 @@ namespace CalamityMod.NPCs
         #endregion
 
         #region Splitting Worm Loot
+        internal static void SplittingWormBroadcastInteractionWrapper(NPC npc, int player)
+        {
+            if (!CalamityWorld.death)
+                return;
+
+            switch (npc.type)
+            {
+                case NPCID.DiggerHead:
+                case NPCID.DiggerBody:
+                case NPCID.DiggerTail:
+                    SplittingWormBroadcastInteraction(npc, player, NPCID.DiggerHead, NPCID.DiggerBody, NPCID.DiggerTail);
+                    return;
+                case NPCID.SeekerHead:
+                case NPCID.SeekerBody:
+                case NPCID.SeekerTail:
+                    SplittingWormBroadcastInteraction(npc, player, NPCID.SeekerHead, NPCID.SeekerBody, NPCID.SeekerTail);
+                    return;
+                case NPCID.DuneSplicerHead:
+                case NPCID.DuneSplicerBody:
+                case NPCID.DuneSplicerTail:
+                    SplittingWormBroadcastInteraction(npc, player, NPCID.DuneSplicerHead, NPCID.DuneSplicerBody, NPCID.DuneSplicerTail);
+                    return;
+            }
+        }
+
+        internal static void SplittingWormBroadcastInteraction(NPC npc, int player, int head, int body, int tail)
+        {
+            for (int i = 0; i < Main.maxNPCs; i++)
+            {
+                if (i != npc.whoAmI && Main.npc[i].active && (Main.npc[i].type == head || Main.npc[i].type == body || Main.npc[i].type == tail))
+                {
+                    Main.npc[i].ApplyInteraction(player);
+                }
+            }
+        }
+
+        internal static void SplittingWormBestiaryUpdate(NPC npc)
+        {
+            if (!CalamityWorld.death)
+                return;
+
+            switch (npc.type)
+            {
+                case NPCID.DiggerBody:
+                case NPCID.DiggerTail:
+                    NPC diggerHead = new();
+                    diggerHead.SetDefaults(NPCID.DiggerHead);
+                    Main.BestiaryTracker.Kills.RegisterKill(diggerHead);
+                    return;
+                case NPCID.SeekerBody:
+                case NPCID.SeekerTail:
+                    NPC seekerHead = new();
+                    seekerHead.SetDefaults(NPCID.SeekerHead);
+                    Main.BestiaryTracker.Kills.RegisterKill(seekerHead);
+                    return;
+                case NPCID.DuneSplicerBody:
+                case NPCID.DuneSplicerTail:
+                    NPC duneSplicerHead = new();
+                    duneSplicerHead.SetDefaults(NPCID.DuneSplicerHead);
+                    Main.BestiaryTracker.Kills.RegisterKill(duneSplicerHead);
+                    return;
+            }
+        }
+
         internal static bool SplittingWormLootBlockWrapper(NPC npc, Mod mod)
         {
             if (!CalamityWorld.death)


### PR DESCRIPTION
Death mode splitting worms can be problematic for bestiary(or also tally counter). Bestiary entry for the splitting worms are incremented only when the killed npc is the head segment and it has been interacted at least once. These two conditions may be violated because `NPC.NPCLoot` only triggers once because of the splitting worm banner fix. This PR solves the problem.