### PR TITLE
Fix Baby Cannonball Jellyfish bestiary bug

### DIFF
--- a/NPCs/Abyss/BabyCannonballJellyfish.cs
+++ b/NPCs/Abyss/BabyCannonballJellyfish.cs
@@ -19,11 +19,12 @@ namespace CalamityMod.NPCs.Abyss
     public class BabyCannonballJellyfish : ModNPC
     {
         public bool hasBeenHit = false;
+        public int explosionDamage;
 
         public override void SetStaticDefaults()
         {
             Main.npcFrameCount[NPC.type] = 7;
-            //Main.npcCatchable[NPC.type] = true;
+            Main.npcCatchable[NPC.type] = true;
             NPCID.Sets.CountsAsCritter[NPC.type] = true;
         }
 
@@ -34,7 +35,8 @@ namespace CalamityMod.NPCs.Abyss
             NPC.chaseable = false;
             NPC.aiStyle = -1;
             AIType = -1;
-            NPC.damage = 30;
+            NPC.damage = 0;
+            explosionDamage = 30;
             NPC.width = 28;
             NPC.height = 36;
             NPC.defense = 0;
@@ -157,7 +159,7 @@ namespace CalamityMod.NPCs.Abyss
             NPC.position -= NPC.Size * 0.5f; //hitbox expansion + adjustments
             SoundEngine.PlaySound(SoundID.Item14, NPC.Center); //bomb sound
             foreach (Player player in Main.player.Where(player => player.active && !player.dead && NPC.Hitbox.Intersects(player.Hitbox)))
-                player.Hurt(PlayerDeathReason.ByNPC(NPC.whoAmI), NPC.damage, NPC.direction);
+                player.Hurt(PlayerDeathReason.ByNPC(NPC.whoAmI), explosionDamage, NPC.direction);
             for (int k = 0; k < 8; k++)
             {
                 int dust = Dust.NewDust(NPC.position, NPC.width, NPC.height, DustID.MoonBoulder, 0f, -1f, 0, default, 1f);
@@ -168,8 +170,6 @@ namespace CalamityMod.NPCs.Abyss
             NPC.NPCLoot();
             NPC.netUpdate = true;
         }
-
-        public override bool CanHitPlayer(Player target, ref int cooldownSlot) => NPC.life <= 0;
 
         public override void HitEffect(NPC.HitInfo hit)
         {


### PR DESCRIPTION
For a NPC to be tracked by bestiary as a critter, the getter property `NPC.CountsAsACritter` should be true. This requires `NPC.damage == 0`, but Baby Cannonball Jellyfish does have damage `30`.  The getter property seems to be inlined, detouring didn't work. Instead I transferred `NPC.damage` to `explosionDamage`, since it didn't deal contact damage afterall. This way, `CanHitPlayer` overriding can be avoided. But there are some problems such as Mythril Sword doesn't reduce the explosion damage anymore.