### PR TITLE
Fix IndexOutOfRangeException in ILChanges.ColorBlightedGel

### DIFF
--- a/ILEditing/VanillaStupidityFixingILChanges.cs
+++ b/ILEditing/VanillaStupidityFixingILChanges.cs
@@ -289,7 +289,7 @@ namespace CalamityMod.ILEditing
 
             // Sync the color changes.
             if (colorWasChanged)
-                NetMessage.SendData(MessageID.ItemTweaker, -1, -1, null, itemID, 1f);
+                NetMessage.SendData(MessageID.ItemTweaker, -1, -1, null, itemIndex, 1f);
         }
         #endregion Color Blighted Gel
 


### PR DESCRIPTION
The parameter needs to be the item index, not item type.

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Terraria.NetMessage.SendData(Int32 msgType, Int32 remoteClient, Int32 ignoreClient, NetworkText text, Int32 number, Single number2, Single number3, Single number4, Int32 number5, Int32 number6, Int32 number7) in tModLoader\Terraria\NetMessage.cs:line 78
   at CalamityMod.ILEditing.ILChanges.ColorBlightedGel(orig_ModifyItemDropFromNPC orig, NPC npc, Int32 itemIndex) in CalamityMod\ILEditing\VanillaStupidityFixingILChanges.cs:line 292
   at Hook<System.Void CalamityMod.ILEditing.ILChanges::ColorBlightedGel(Terraria.GameContent.ItemDropRules.On_CommonCode+orig_ModifyItemDropFromNPC,Terraria.NPC,System.Int32)>(NPC , Int32 )
   at SyncProxy<System.Void Terraria.GameContent.ItemDropRules.CommonCode:ModifyItemDropFromNPC(Terraria.NPC, System.Int32)>(NPC , Int32 )
   at Terraria.GameContent.ItemDropRules.CommonDrop.TryDroppingItem(DropAttemptInfo info) in tModLoader\Terraria\GameContent\ItemDropRules\CommonDrop.cs:line 44
   at Terraria.GameContent.ItemDropRules.ItemDropResolver.ResolveRule(IItemDropRule rule, DropAttemptInfo info) in tModLoader\Terraria\GameContent\ItemDropRules\ItemDropResolver.cs:line 31```