### PR TITLE
Removed duplicate Harvest Staff tooltip

### DIFF
--- a/Localization/en-US/Mods.CalamityMod.Items.Weapons.Magic.hjson
+++ b/Localization/en-US/Mods.CalamityMod.Items.Weapons.Magic.hjson
@@ -392,11 +392,6 @@ HadalUrn: {
 		'''
 }
 
-HarvestStaff: {
-	DisplayName: Harvest Staff
-	Tooltip: Casts flaming pumpkins
-}
-
 HeliumFlash: {
 	DisplayName: Helium Flash
 	Tooltip:


### PR DESCRIPTION
Harvest Staff still has its localisation entry from when it was a Magic weapon, though it's not used in game.