### PR TITLE
Slab Crabs cannot spawn

### DIFF
--- a/NPCs/Abyss/SlabCrab.cs
+++ b/NPCs/Abyss/SlabCrab.cs
@@ -309,7 +309,7 @@ namespace CalamityMod.NPCs.Abyss
         {
             if (spawnInfo.Player.Calamity().ZoneAbyssLayer1 && spawnInfo.Water)
             {
-                return SpawnCondition.OceanMonster.Chance;
+                return SpawnCondition.CaveJellyfish.Chance;
             }
             return 0f;
         }


### PR DESCRIPTION
Slab Crab spawn uses `OceanMonster` condition (which makes it impossible to spawn) when it should use `CaveJellyfish` condition like the other Abyssal NPCs.