### PR TITLE
Small netcode improvement

### DIFF
--- a/Projectiles/Melee/BladecrestOathswordProj.cs
+++ b/Projectiles/Melee/BladecrestOathswordProj.cs
@@ -16,7 +16,7 @@ namespace CalamityMod.Projectiles.Melee
     public class BladecrestOathswordProj : BaseIdleHoldoutProjectile
     {
         public override LocalizedText DisplayName => CalamityUtils.GetItemName<BladecrestOathsword>();
-        public enum SwingState
+        public enum SwingState : byte
         {
             Default,
             Swinging
@@ -57,14 +57,14 @@ namespace CalamityMod.Projectiles.Melee
         {
             writer.Write(Direction);
             writer.Write(PostSwingRepositionDelay);
-            writer.Write((int)CurrentState);
+            writer.Write((byte)CurrentState);
         }
 
         public override void ReceiveExtraAI(BinaryReader reader)
         {
             Direction = reader.ReadInt32();
             PostSwingRepositionDelay = reader.ReadSingle();
-            CurrentState = (SwingState)reader.ReadInt32();
+            CurrentState = (SwingState)reader.ReadByte();
         }
 
         public override void SafeAI()

--- a/Projectiles/Melee/OldLordClaymoreProj.cs
+++ b/Projectiles/Melee/OldLordClaymoreProj.cs
@@ -16,7 +16,7 @@ namespace CalamityMod.Projectiles.Melee
     public class OldLordClaymoreProj : BaseIdleHoldoutProjectile
     {
         public override LocalizedText DisplayName => CalamityUtils.GetItemName<OldLordClaymore>();
-        public enum SwingState
+        public enum SwingState : byte
         {
             Default,
             Swinging,
@@ -63,7 +63,7 @@ namespace CalamityMod.Projectiles.Melee
             writer.Write(Direction);
             writer.Write(PostSwingRepositionDelay);
             writer.Write(ChargePower);
-            writer.Write((int)CurrentState);
+            writer.Write((byte)CurrentState);
         }
 
         public override void ReceiveExtraAI(BinaryReader reader)
@@ -71,7 +71,7 @@ namespace CalamityMod.Projectiles.Melee
             Direction = reader.ReadInt32();
             PostSwingRepositionDelay = reader.ReadSingle();
             ChargePower = reader.ReadSingle();
-            CurrentState = (SwingState)reader.ReadInt32();
+            CurrentState = (SwingState)reader.ReadByte();
         }
 
         public override void SafeAI()

--- a/Projectiles/Summon/GlacialEmbracePointyThing.cs
+++ b/Projectiles/Summon/GlacialEmbracePointyThing.cs
@@ -76,7 +76,7 @@ namespace CalamityMod.Projectiles.Summon
             writer.Write(recharging);
             writer.Write(circling);
             writer.Write(circlingPlayer);
-            writer.Write((double)floatyDistance);
+            writer.Write(floatyDistance);
             writer.Write(target is null ? -1 : target.whoAmI);
         }
         public override void ReceiveExtraAI(BinaryReader reader)
@@ -84,7 +84,7 @@ namespace CalamityMod.Projectiles.Summon
             recharging = reader.ReadInt32();
             circling = reader.ReadBoolean();
             circlingPlayer = reader.ReadBoolean();
-            floatyDistance = (float)reader.ReadDouble();
+            floatyDistance = reader.ReadSingle();
             int targ = reader.ReadInt32();
             target = targ == -1 ? null : Main.npc[targ];
         }


### PR DESCRIPTION
This PR do some nitpick fixes I found on netcode

# GlacialEmbrance Projectile
There are no meaningful reason `float` being casted to `double` when sending packet. And cast it back to `float`

# Oathsword Projectile, Old Lord Claymore Projectile
Casting `state` variable to byte as it does not goes up to 255

# Pumpler Gun Visual Projectile
Instead of syncing full float for `Overfilled` State, it now sends as `bool`, and instead of do exact comparison `Overfilled == 0.0f` they now do half-point check:
```cs
IsOverfilled = (Overfilled > 0.5f);
```
(This could be replaced to bool field possibly)