### PR TITLE
Fix Issues With Quick Heal and Quick Mana

### DIFF
--- a/Items/Potions/Alcohol/RedWine.cs
+++ b/Items/Potions/Alcohol/RedWine.cs
@@ -30,15 +30,10 @@ namespace CalamityMod.Items.Potions.Alcohol
             Item.value = Item.buyPrice(0, 0, 65, 0);
         }
 
-        public override bool? UseItem(Player player)
-        {
-            Item.healLife = player.Calamity().baguette ? 250 : 200;
-            return null;
-        }
-
         public override void OnConsumeItem(Player player)
         {
             player.AddBuff(ModContent.BuffType<RedWineBuff>(), 900);
+            Item.healLife = player.Calamity().baguette ? 250 : 200;
         }
     }
 }

--- a/Items/Potions/Alcohol/WhiteWine.cs
+++ b/Items/Potions/Alcohol/WhiteWine.cs
@@ -32,7 +32,7 @@ namespace CalamityMod.Items.Potions.Alcohol
             Item.value = Item.buyPrice(0, 4, 0, 0);
         }
 
-        public override bool? UseItem(Player player)
+        public override void OnConsumeItem(Player player)
         {
             if (PlayerInput.Triggers.JustPressed.QuickBuff)
             {
@@ -48,7 +48,6 @@ namespace CalamityMod.Items.Potions.Alcohol
                 }
             }
             player.AddBuff(Item.buffType, Item.buffTime);
-            return true;
         }
     }
 }

--- a/Items/Potions/AureusCell.cs
+++ b/Items/Potions/AureusCell.cs
@@ -32,7 +32,7 @@ namespace CalamityMod.Items.Potions
             Item.buffTime = CalamityUtils.SecondsToFrames(360f);
         }
 
-        public override bool? UseItem(Player player)
+        public override void OnConsumeItem(Player player)
         {
             if (PlayerInput.Triggers.JustPressed.QuickBuff)
             {
@@ -49,7 +49,6 @@ namespace CalamityMod.Items.Potions
             }
             player.AddBuff(BuffID.MagicPower, Item.buffTime);
             player.AddBuff(BuffID.ManaRegeneration, Item.buffTime);
-            return true;
         }
     }
 }

--- a/Items/Potions/HadalStew.cs
+++ b/Items/Potions/HadalStew.cs
@@ -52,12 +52,11 @@ namespace CalamityMod.Items.Potions
             return player.potionDelay <= 0 && player.Calamity().potionTimer <= 0;
         }
 
-        public override bool? UseItem(Player player)
+        public override void OnConsumeItem(Player player)
         {
             player.AddBuff(BuffType, BuffDuration);
             // fixes hardcoded potion sickness duration from quick heal (see CalamityPlayerMiscEffects.cs)
             player.Calamity().potionTimer = 2;
-            return true;
         }
 
         public override void AddRecipes()


### PR DESCRIPTION
-Fixed Red Wine not healing more with baguette when using quick Heal
-Fixed White Wine not applying the white wine buff when using quick mana
-Fixed Aureus Cells not applying Magic Power or Mana Regen when using quick mana
-Fixed Hadal Stew not giving 50 seconds of potion sickness when using quick heal