### PR TITLE
Abyss Overhead fix

### DIFF
--- a/Tiles/Abyss/AbyssAmbient/ThermalVent.cs
+++ b/Tiles/Abyss/AbyssAmbient/ThermalVent.cs
@@ -71,13 +71,18 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 
             if (!Main.gamePaused && t.TileFrameX % 36 == 0 && t.TileFrameY % 36 == 0 && Collision.CanHitLine(spawnPosition, 1, 1, spawnPosition - Vector2.UnitY * 100f, 1, 1))
             {
+                if (steamTimer <= 450)
+                    return;
+
+                if (!Main.rand.NextBool(3))
+                    return;
+
                 float positionInterpolant = (i + j) * 0.041f % 1f;
                 Vector2 smokeVelocity = -Vector2.UnitY.RotatedByRandom(0.11f) * MathHelper.Lerp(4.8f, 8.1f, positionInterpolant);
                 smokeVelocity.X += (float)Math.Cos(MathHelper.TwoPi * positionInterpolant) * 1.1f;
                 smokeVelocity.Y -= Main.rand.Next(3, 6);
 
-                if (steamTimer >= 450 && Main.rand.NextBool(3))
-                    Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<ThermalSteam>(), Main.expertMode ? 20 : 30, 0f);
+                Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<ThermalSteam>(), Main.expertMode ? 20 : 30, 0f);
             }
         }
     }

--- a/Tiles/Abyss/SteamGeyser.cs
+++ b/Tiles/Abyss/SteamGeyser.cs
@@ -54,13 +54,18 @@ namespace CalamityMod.Tiles.Abyss
 
             if (!Main.gamePaused && t.TileFrameX % 36 == 0 && t.TileFrameY % 36 == 0 && Collision.CanHitLine(spawnPosition, 1, 1, spawnPosition - Vector2.UnitY * 100f, 1, 1))
             {
+                if (steamTimer <= 180)
+                    return;
+
+                if (!Main.rand.NextBool(3))
+                    return;
+
                 float positionInterpolant = (i + j) * 0.041f % 1f;
                 Vector2 smokeVelocity = -Vector2.UnitY.RotatedByRandom(0.11f) * MathHelper.Lerp(4.8f, 8.1f, positionInterpolant);
                 smokeVelocity.X += (float)Math.Cos(MathHelper.TwoPi * positionInterpolant) * 1.1f;
                 smokeVelocity.Y -= Main.rand.Next(3, 6);
 
-                if (steamTimer >= 180 && Main.rand.NextBool(3))
-                    Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<HotSteam>(), Main.expertMode ? 15 : 23, 0f);
+                Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<HotSteam>(), Main.expertMode ? 15 : 23, 0f);
             }
         }
     }

--- a/Walls/VoidstoneWall.cs
+++ b/Walls/VoidstoneWall.cs
@@ -12,13 +12,29 @@ namespace CalamityMod.Walls
     public class VoidstoneWall : ModWall
     {
         internal static Texture2D GlowTexture;
+        internal static bool[,] GlowTexture_NonEmptyFrame = new bool[13, 5];
+
 
         public override void SetStaticDefaults()
         {
             Main.wallHouse[Type] = true;
             GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Walls/VoidstoneWall_Glowmask", AssetRequestMode.ImmediateLoad).Value;
 
+            // Hardcoded way to filter the Glowing frames
+            // Potentially be replaced to loop which look for actual pixel in certain frame
+            Array.Clear(GlowTexture_NonEmptyFrame);
+            GlowTexture_NonEmptyFrame[7, 2] = true;
+            GlowTexture_NonEmptyFrame[10, 0] = true;
+            GlowTexture_NonEmptyFrame[11, 1] = true;
+
             AddMapEntry(new Color(0, 0, 0));
+        }
+
+        public static bool IsGlowIncludedInFrame(Rectangle frame)
+        {
+            int x = frame.X / 36;
+            int y = frame.Y / 36;
+            return GlowTexture_NonEmptyFrame[x, y];
         }
 
         public override bool CreateDust(int i, int j, ref int type)
@@ -54,12 +70,16 @@ namespace CalamityMod.Walls
                 zero = Vector2.Zero;
 
             Vector2 pos = new Vector2(i * 16 - (int)Main.screenPosition.X, j * 16 - (int)Main.screenPosition.Y) + zero;
-            Main.spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+            spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
             Color glowColor = drawcolor * 0.4f;
-            for (int k = 0; k < 3; k++)
+            
+            if (IsGlowIncludedInFrame(frame))
             {
-                Vector2 offset = new Vector2(Main.rand.NextFloat(-1, 1f), Main.rand.NextFloat(-1, 1f)) * 0.2f * k;
-                Main.spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                for (int k = 0; k < 3; k++)
+                {
+                    Vector2 offset = new Vector2(Main.rand.NextFloat(-1, 1f), Main.rand.NextFloat(-1, 1f)) * 0.2f * k;
+                    spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                }
             }
         }
 

--- a/Walls/VoidstoneWallUnsafe.cs
+++ b/Walls/VoidstoneWallUnsafe.cs
@@ -59,12 +59,18 @@ namespace CalamityMod.Walls
                 zero = Vector2.Zero;
 
             Vector2 pos = new Vector2((i * 16 - (int)Main.screenPosition.X), (j * 16 - (int)Main.screenPosition.Y)) + zero;
-            Main.spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+            spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
             Color glowColor = drawcolor * 0.4f;
-            for (int k = 0; k < 3; k++)
+
+            if (VoidstoneWall.IsGlowIncludedInFrame(frame))
             {
-                Vector2 offset = new Vector2(Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-1f, 1f)) * 0.2f * k;
-                Main.spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                // For now checking for glowing frames greatly reducing the bottleneck
+                // But maybe we could squeeze bit more by removing the loop
+                for (int k = 0; k < 3; k++)
+                {
+                    Vector2 offset = new Vector2(Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-1f, 1f)) * 0.2f * k;
+                    spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                }
             }
         }
 


### PR DESCRIPTION
# Fixing for:
- Abyss Hazards tiles always calculate for their projectile whether they actually spawn one or not
- **[Critical]** VoidStoneWall always draw glow (x3 times for some reason) even if they don't have one in frame
# Quick VoidStoneWall fix performance comparison
## Before:
![before_patch](https://github.com/user-attachments/assets/4b52dfa7-8044-4f21-a2c3-b29aeeb1148f)
## After:
![after_patch](https://github.com/user-attachments/assets/3c6267e6-eea4-437a-a80e-8a1dbac819fb)