### PR TITLE
GlowMask and Abyss related Overhead Fix

### DIFF
--- a/CalamityMod.cs
+++ b/CalamityMod.cs
@@ -447,6 +447,7 @@ namespace CalamityMod
             NPCStats.Unload();
             CalamityGlobalItem.UnloadTweaks();
             CalamityGlobalProjectile.UnloadTweaks();
+            FramedGlowMask.UnloadTexCache();
 
             PopupGUIManager.UnloadGUIs();
             InvasionProgressUIManager.UnloadGUIs();

--- a/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp1.cs
+++ b/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp1.cs
@@ -12,8 +12,16 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class AbyssGiantKelp1 : ModTile
     {
+        protected virtual string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp1Glow";
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            if (!string.IsNullOrEmpty(GlowAsset))
+            {
+                GlowMask = new(GlowAsset, 18, 18);
+            }
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             TileObjectData.newTile.Width = 2;
@@ -65,23 +73,20 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp1Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask is not null && GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                Vector2 pos = new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero;
+                Rectangle frame = new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16);
+                spriteBatch.Draw(GlowMask.Texture, pos, frame, Color.White);
+            }
         }
     }
 
     //just clone the first one its literally the same size
     public class AbyssGiantKelp2 : AbyssGiantKelp1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp2Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp2Glow";
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp3.cs
+++ b/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp3.cs
@@ -12,8 +12,12 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class AbyssGiantKelp3 : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp3Glow", 18, 18);
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             TileObjectData.newTile.Width = 2;
@@ -65,10 +69,12 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp3Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                spriteBatch.Draw(GlowMask.Texture, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            }
         }
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp4.cs
+++ b/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp4.cs
@@ -12,8 +12,12 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class AbyssGiantKelp4 : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp4Glow", 18, 18);
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             TileObjectData.newTile.Width = 2;
@@ -65,10 +69,12 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/AbyssGiantKelp4Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                spriteBatch.Draw(GlowMask.Texture, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            }
         }
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/BulbTree.cs
+++ b/Tiles/Abyss/AbyssAmbient/BulbTree.cs
@@ -11,8 +11,16 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class BulbTree1 : ModTile
     {
+        protected virtual string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree1Glow";
+        internal static FramedGlowMask GlowMask; 
+
         public override void SetStaticDefaults()
         {
+            if (!string.IsNullOrEmpty(GlowAsset))
+            {
+                GlowMask = new(GlowAsset, 18, 18);
+            }
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             TileObjectData.newTile.Width = 3;
@@ -48,34 +56,24 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree1Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask is not null && GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                Vector2 pos = new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero;
+                Rectangle frame = new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16);
+                spriteBatch.Draw(GlowMask.Texture, pos, frame, Color.White);
+            }
         }
     }
 
     public class BulbTree2 : BulbTree1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree2Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree3Glow";
     }
 
     public class BulbTree3 : BulbTree1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree3Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/BulbTree3Glow";
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/PirateCrate.cs
+++ b/Tiles/Abyss/AbyssAmbient/PirateCrate.cs
@@ -9,11 +9,22 @@ using Terraria.ObjectData;
 
 namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
+    //
+    // Pirate Crate With Glow
+
     public class PirateCrate1 : ModTile
     {
+        protected virtual string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate1Glow";
+        internal static FramedGlowMask GlowMask;
+
         public static readonly SoundStyle MineSound = new("CalamityMod/Sounds/Custom/CrateBreak", 3) { Volume = 0.8f };
         public override void SetStaticDefaults()
         {
+            if (!string.IsNullOrEmpty(GlowAsset))
+            {
+                GlowMask = new(GlowAsset, 18, 18);
+            }
+
             Main.tileFrameImportant[Type] = true;
             Main.tileLavaDeath[Type] = true;
             Main.tileWaterDeath[Type] = false;
@@ -44,36 +55,29 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate1Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask is not null && GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                Vector2 pos = new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero;
+                Rectangle frame = new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16);
+                spriteBatch.Draw(GlowMask.Texture, pos, frame, Color.White);
+            }
         }
     }
 
     public class PirateCrate2 : PirateCrate1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate2Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate2Glow";
     }
 
     public class PirateCrate3 : PirateCrate1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate3Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/PirateCrate3Glow";
     }
+
+    //
+    // Pirate Crate Without Glow
 
     public class PirateCrate4 : ModTile
     {

--- a/Tiles/Abyss/AbyssAmbient/SpiderCoral.cs
+++ b/Tiles/Abyss/AbyssAmbient/SpiderCoral.cs
@@ -13,8 +13,16 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class SpiderCoral1 : ModTile
     {
+        protected virtual string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral1Glow";
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            if (!string.IsNullOrEmpty(GlowAsset))
+            {
+                GlowMask = new(GlowAsset, 18, 18);
+            }
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             Main.tileNoAttach[Type] = true;
@@ -36,58 +44,34 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral1Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask is not null && GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                Vector2 pos = new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero;
+                Rectangle frame = new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16);
+                spriteBatch.Draw(GlowMask.Texture, pos, frame, Color.White);
+            }
         }
     }
 
     public class SpiderCoral2 : SpiderCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral2Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral2Glow";
     }
 
     public class SpiderCoral3 : SpiderCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral3Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral3Glow";
     }
 
     public class SpiderCoral4 : SpiderCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral4Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral4Glow";
     }
 
     public class SpiderCoral5 : SpiderCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral5Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SpiderCoral5Glow";
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/SulphurPireCoral.cs
+++ b/Tiles/Abyss/AbyssAmbient/SulphurPireCoral.cs
@@ -11,8 +11,16 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 {
     public class SulphurPireCoral1 : ModTile
     {
+        protected virtual string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral2Glow";
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            if (!string.IsNullOrEmpty(GlowAsset))
+            {
+                GlowMask = new(GlowAsset, 18, 18);
+            }
+
             Main.tileLighted[Type] = true;
             Main.tileFrameImportant[Type] = true;
             TileObjectData.newTile.Width = 3;
@@ -48,34 +56,24 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral1Glow").Value;
             Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
+            if (GlowMask is not null && GlowMask.HasContentInFramePos(tile.TileFrameX, tile.TileFrameY))
+            {
+                Vector2 pos = new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero;
+                Rectangle frame = new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16);
+                spriteBatch.Draw(GlowMask.Texture, pos, frame, Color.White);
+            }
         }
     }
 
     public class SulphurPireCoral2 : SulphurPireCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral2Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral2Glow";
     }
 
     public class SulphurPireCoral3 : SulphurPireCoral1
     {
-        public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
-        {
-            Tile tile = Framing.GetTileSafely(i, j);
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral3Glow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange, Main.offScreenRange);
-
-            spriteBatch.Draw(tex, new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + zero, new Rectangle(tile.TileFrameX, tile.TileFrameY, 16, 16), Color.White);
-        }
+        protected override string GlowAsset => "CalamityMod/Tiles/Abyss/AbyssAmbient/SulphurPireCoral3Glow";
     }
 }

--- a/Tiles/Abyss/AbyssAmbient/ThermalVent.cs
+++ b/Tiles/Abyss/AbyssAmbient/ThermalVent.cs
@@ -71,13 +71,18 @@ namespace CalamityMod.Tiles.Abyss.AbyssAmbient
 
             if (!Main.gamePaused && t.TileFrameX % 36 == 0 && t.TileFrameY % 36 == 0 && Collision.CanHitLine(spawnPosition, 1, 1, spawnPosition - Vector2.UnitY * 100f, 1, 1))
             {
+                if (steamTimer <= 450)
+                    return;
+
+                if (!Main.rand.NextBool(3))
+                    return;
+
                 float positionInterpolant = (i + j) * 0.041f % 1f;
                 Vector2 smokeVelocity = -Vector2.UnitY.RotatedByRandom(0.11f) * MathHelper.Lerp(4.8f, 8.1f, positionInterpolant);
                 smokeVelocity.X += (float)Math.Cos(MathHelper.TwoPi * positionInterpolant) * 1.1f;
                 smokeVelocity.Y -= Main.rand.Next(3, 6);
 
-                if (steamTimer >= 450 && Main.rand.NextBool(3))
-                    Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<ThermalSteam>(), Main.expertMode ? 20 : 30, 0f);
+                Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<ThermalSteam>(), Main.expertMode ? 20 : 30, 0f);
             }
         }
     }

--- a/Tiles/Abyss/PyreMantleMolten.cs
+++ b/Tiles/Abyss/PyreMantleMolten.cs
@@ -14,12 +14,12 @@ namespace CalamityMod.Tiles.Abyss
     public class PyreMantleMolten : ModTile
     {
         public static readonly SoundStyle MineSound = new("CalamityMod/Sounds/Custom/VoidstoneMine", 3) { Volume = 0.4f };
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
+
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/PyreMantleMolten_Glowmask", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/Abyss/PyreMantleMolten_Glowmask", 18, 18);
 
             Main.tileLighted[Type] = true;
             Main.tileSolid[Type] = true;
@@ -76,23 +76,26 @@ namespace CalamityMod.Tiles.Abyss
 
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(200, 200, 200, 200));
-            Tile trackTile = Main.tile[i, j];
-            float glowbrightness = 1f;
-            float glowspeed = Main.GameUpdateCount * 0.01f;
-            glowbrightness *= (float)MathF.Sin(i / 60f + glowspeed);
-            drawColour *= glowbrightness;
-            double num6 = Main.time * 0.08;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
-            glowbrightness += 0.3f;
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(200, 200, 200, 200));
+                Tile trackTile = Main.tile[i, j];
+                float glowbrightness = 1f;
+                float glowspeed = Main.GameUpdateCount * 0.01f;
+                glowbrightness *= (float)MathF.Sin(i / 60f + glowspeed);
+                drawColour *= glowbrightness;
+                double num6 = Main.time * 0.08;
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+                glowbrightness += 0.3f;
+            }
         }
 
         public override void ModifyLight(int i, int j, ref float r, ref float g, ref float b)

--- a/Tiles/Abyss/SteamGeyser.cs
+++ b/Tiles/Abyss/SteamGeyser.cs
@@ -54,13 +54,18 @@ namespace CalamityMod.Tiles.Abyss
 
             if (!Main.gamePaused && t.TileFrameX % 36 == 0 && t.TileFrameY % 36 == 0 && Collision.CanHitLine(spawnPosition, 1, 1, spawnPosition - Vector2.UnitY * 100f, 1, 1))
             {
+                if (steamTimer <= 180)
+                    return;
+
+                if (!Main.rand.NextBool(3))
+                    return;
+
                 float positionInterpolant = (i + j) * 0.041f % 1f;
                 Vector2 smokeVelocity = -Vector2.UnitY.RotatedByRandom(0.11f) * MathHelper.Lerp(4.8f, 8.1f, positionInterpolant);
                 smokeVelocity.X += (float)Math.Cos(MathHelper.TwoPi * positionInterpolant) * 1.1f;
                 smokeVelocity.Y -= Main.rand.Next(3, 6);
 
-                if (steamTimer >= 180 && Main.rand.NextBool(3))
-                    Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<HotSteam>(), Main.expertMode ? 15 : 23, 0f);
+                Projectile.NewProjectile(new EntitySource_WorldEvent(), spawnPosition, smokeVelocity, ModContent.ProjectileType<HotSteam>(), Main.expertMode ? 15 : 23, 0f);
             }
         }
     }

--- a/Tiles/Abyss/Voidstone.cs
+++ b/Tiles/Abyss/Voidstone.cs
@@ -14,12 +14,11 @@ namespace CalamityMod.Tiles.Abyss
     public class Voidstone : ModTile
     {
         public static readonly SoundStyle MineSound = new("CalamityMod/Sounds/Custom/VoidstoneMine", 3) { Volume = 0.4f };
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/Abyss/Voidstone_Glowmask", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/Abyss/Voidstone_Glowmask", 18, 18);
 
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -167,7 +166,7 @@ namespace CalamityMod.Tiles.Abyss
 
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             int xPos = Main.tile[i, j].TileFrameX;
@@ -261,19 +260,23 @@ namespace CalamityMod.Tiles.Abyss
 
             xOffset *= 234;
             xPos += xOffset;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(255, 255, 255, 255));
-            Tile trackTile = Main.tile[i, j];
-            float brightness = 1f;
-            float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
-            brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            drawColour *= brightness;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(255, 255, 255, 255));
+                Tile trackTile = Main.tile[i, j];
+                float brightness = 1f;
+                float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
+                brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= 0.5f;
+                drawColour *= brightness;
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/AstralBrick.cs
+++ b/Tiles/AstralBrick.cs
@@ -14,9 +14,13 @@ namespace CalamityMod.Tiles
         private const short subsheetWidth = 324;
         private const short subsheetHeight = 90;
 
+        internal static FramedGlowMask GlowMask;
+
 
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/AstralBrickGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = SoundID.Tink;
@@ -55,13 +59,16 @@ namespace CalamityMod.Tiles
             yOffset *= subsheetHeight;
             xPos += xOffset;
             yPos += yOffset;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/AstralBrickGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(50, 50, 50, 50));
-            Tile trackTile = Main.tile[i, j];
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(50, 50, 50, 50));
+                Tile trackTile = Main.tile[i, j];
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureAshen/SmoothBrimstoneSlag.cs
+++ b/Tiles/FurnitureAshen/SmoothBrimstoneSlag.cs
@@ -9,8 +9,12 @@ namespace CalamityMod.Tiles.FurnitureAshen
 {
     public class SmoothBrimstoneSlag : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureAshen/SmoothBrimstoneSlagGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileMergeDirt[Type] = false;
             Main.tileBlockLight[Type] = true;
@@ -36,13 +40,16 @@ namespace CalamityMod.Tiles.FurnitureAshen
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureAshen/SmoothBrimstoneSlagGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(25, 25, 25, 25));
-            Tile trackTile = Main.tile[i, j];
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(25, 25, 25, 25));
+                Tile trackTile = Main.tile[i, j];
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureAuric/ActivatedAuricPanelTile.cs
+++ b/Tiles/FurnitureAuric/ActivatedAuricPanelTile.cs
@@ -11,11 +11,12 @@ namespace CalamityMod.Tiles.FurnitureAuric
 {
     public class ActivatedAuricPanelTile : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureAuric/ActivatedAuricPanelTile_Glow", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/FurnitureAuric/ActivatedAuricPanelTile_Glow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = AuricOre.MineSound;
@@ -34,13 +35,17 @@ namespace CalamityMod.Tiles.FurnitureAuric
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureAuric/AuricRepulserPanelTile.cs
+++ b/Tiles/FurnitureAuric/AuricRepulserPanelTile.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Diagnostics;
 using CalamityMod.Tiles.Ores;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -11,11 +12,12 @@ namespace CalamityMod.Tiles.FurnitureAuric
 {
     public class AuricRepulserPanelTile : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureAuric/AuricRepulserPanelTile_Glow", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/FurnitureAuric/AuricRepulserPanelTile_Glow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = AuricOre.MineSound;
@@ -34,13 +36,17 @@ namespace CalamityMod.Tiles.FurnitureAuric
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureAuric/ExoAuricPanelTile.cs
+++ b/Tiles/FurnitureAuric/ExoAuricPanelTile.cs
@@ -11,11 +11,12 @@ namespace CalamityMod.Tiles.FurnitureAuric
 {
     public class ExoAuricPanelTile : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureAuric/ExoAuricPanelTile_Glow", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/FurnitureAuric/ExoAuricPanelTile_Glow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = AuricOre.MineSound;
@@ -34,13 +35,17 @@ namespace CalamityMod.Tiles.FurnitureAuric
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureCosmilite/CosmiliteBrick.cs
+++ b/Tiles/FurnitureCosmilite/CosmiliteBrick.cs
@@ -9,8 +9,12 @@ namespace CalamityMod.Tiles.FurnitureCosmilite
 {
     public class CosmiliteBrick : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureCosmilite/CosmiliteBrickGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = SoundID.Tink;
@@ -29,14 +33,17 @@ namespace CalamityMod.Tiles.FurnitureCosmilite
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureCosmilite/CosmiliteBrickGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureExo/ExoPlatingTile.cs
+++ b/Tiles/FurnitureExo/ExoPlatingTile.cs
@@ -10,14 +10,11 @@ namespace CalamityMod.Tiles.FurnitureExo
 {
     public class ExoPlatingTile : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-            {
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureExo/ExoPlatingTileGlow", AssetRequestMode.ImmediateLoad).Value;
-            }
+            GlowMask = new("CalamityMod/Tiles/FurnitureExo/ExoPlatingTileGlow", 18, 18);
 
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -48,18 +45,22 @@ namespace CalamityMod.Tiles.FurnitureExo
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             // If the cached textures don't exist for some reason, don't bother using them.
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             Tile tile = CalamityUtils.ParanoidTileRetrieval(i, j);
             int xPos = tile.TileFrameX;
             int frameOffset = j % 2 * AnimationFrameHeight;
             int yPos = tile.TileFrameY + frameOffset;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Vector2 drawOffset = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawPosition = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + drawOffset;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Vector2 drawOffset = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawPosition = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + drawOffset;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
         private Color GetDrawColour(int i, int j, Color colour)
         {

--- a/Tiles/FurnitureExo/ExoPrismPanelTile.cs
+++ b/Tiles/FurnitureExo/ExoPrismPanelTile.cs
@@ -10,14 +10,11 @@ namespace CalamityMod.Tiles.FurnitureExo
 {
     public class ExoPrismPanelTile : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-            {
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureExo/ExoPrismPanelTileGlow", AssetRequestMode.ImmediateLoad).Value;
-            }
+            GlowMask = new("CalamityMod/Tiles/FurnitureExo/ExoPrismPanelTileGlow", 18, 18);
 
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -48,18 +45,22 @@ namespace CalamityMod.Tiles.FurnitureExo
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
             // If the cached textures don't exist for some reason, don't bother using them.
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             Tile tile = CalamityUtils.ParanoidTileRetrieval(i, j);
             int xPos = tile.TileFrameX;
             int frameOffset = (i + j) % 6 * AnimationFrameHeight;
             int yPos = tile.TileFrameY + frameOffset;
-            Color drawColour = GetDrawColour(i, j, Color.White);
-            Vector2 drawOffset = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawPosition = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + drawOffset;
 
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Color drawColour = GetDrawColour(i, j, Color.White);
+                Vector2 drawOffset = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawPosition = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + drawOffset;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
         private Color GetDrawColour(int i, int j, Color colour)
         {

--- a/Tiles/FurniturePlaguedPlate/PlaguedPlate.cs
+++ b/Tiles/FurniturePlaguedPlate/PlaguedPlate.cs
@@ -9,8 +9,12 @@ namespace CalamityMod.Tiles.FurniturePlaguedPlate
 {
     public class PlaguedPlate : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurniturePlaguedPlate/PlaguedPlateGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             HitSound = SoundID.Tink;
@@ -38,12 +42,15 @@ namespace CalamityMod.Tiles.FurniturePlaguedPlate
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurniturePlaguedPlate/PlaguedPlateGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(128, 128, 128, 128));
-            Tile trackTile = Main.tile[i, j];
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(128, 128, 128, 128));
+                Tile trackTile = Main.tile[i, j];
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureProfaned/ProfanedRock.cs
+++ b/Tiles/FurnitureProfaned/ProfanedRock.cs
@@ -10,8 +10,12 @@ namespace CalamityMod.Tiles.FurnitureProfaned
 {
     public class ProfanedRock : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureProfaned/ProfanedRockGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileMergeDirt[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -127,6 +131,9 @@ namespace CalamityMod.Tiles.FurnitureProfaned
 
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
+            if (GlowMask.Texture is null)
+                return;
+
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
             int xOffset = 0;
@@ -217,13 +224,15 @@ namespace CalamityMod.Tiles.FurnitureProfaned
             }
             xOffset *= 288;
             xPos += xOffset;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureProfaned/ProfanedRockGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(25, 25, 25, 25));
-            Tile trackTile = Main.tile[i, j];
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(25, 25, 25, 25));
+                Tile trackTile = Main.tile[i, j];
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureProfaned/RunicProfanedBrick.cs
+++ b/Tiles/FurnitureProfaned/RunicProfanedBrick.cs
@@ -10,8 +10,12 @@ namespace CalamityMod.Tiles.FurnitureProfaned
 {
     public class RunicProfanedBrick : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureProfaned/RunicProfanedBrickGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
 
@@ -49,13 +53,16 @@ namespace CalamityMod.Tiles.FurnitureProfaned
             yOffset *= AnimationFrameHeight;
             xPos += xOffset;
             yPos += yOffset;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureProfaned/RunicProfanedBrickGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(128, 128, 128, 128));
-            Tile trackTile = Main.tile[i, j];
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(128, 128, 128, 128));
+                Tile trackTile = Main.tile[i, j];
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureStratus/StratusBricks.cs
+++ b/Tiles/FurnitureStratus/StratusBricks.cs
@@ -9,8 +9,12 @@ namespace CalamityMod.Tiles.FurnitureStratus
 {
     public class StratusBricks : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureStratus/StratusBricksGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
             TileID.Sets.HasSlopeFrames[Type] = true;
@@ -38,13 +42,16 @@ namespace CalamityMod.Tiles.FurnitureStratus
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureStratus/StratusBricksGlow").Value;
-            Color drawColour = GetDrawColour(i, j, new Color(100, 100, 100, 100));
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Tile trackTile = Main.tile[i, j];
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Color drawColour = GetDrawColour(i, j, new Color(100, 100, 100, 100));
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Tile trackTile = Main.tile[i, j];
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/FurnitureVoid/SmoothVoidstone.cs
+++ b/Tiles/FurnitureVoid/SmoothVoidstone.cs
@@ -10,8 +10,12 @@ namespace CalamityMod.Tiles.FurnitureVoid
 {
     public class SmoothVoidstone : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/FurnitureVoid/SmoothVoidstoneGlow", 18, 18);
+
             Main.tileSolid[Type] = true;
             Main.tileMergeDirt[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -216,20 +220,23 @@ namespace CalamityMod.Tiles.FurnitureVoid
             }
             xOffset *= 288;
             xPos += xOffset;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/FurnitureVoid/SmoothVoidstoneGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(255, 255, 255, 255));
-            Tile trackTile = Main.tile[i, j];
-            float brightness = 1f;
-            float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
-            brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            drawColour *= brightness;
 
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(255, 255, 255, 255));
+                Tile trackTile = Main.tile[i, j];
+                float brightness = 1f;
+                float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
+                brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                drawColour *= brightness;
+
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/GiantPlanteraBulb.cs
+++ b/Tiles/GiantPlanteraBulb.cs
@@ -15,14 +15,11 @@ namespace CalamityMod.Tiles
 {
     public class GiantPlanteraBulb : ModTile
     {
-        public static Asset<Texture2D> Glow { get; private set; }
+        public static FramedGlowMask GlowMask { get; private set; }
 
         public override void Load()
         {
-            if (!Main.dedServ)
-            {
-                Glow = ModContent.Request<Texture2D>($"{Texture}Glow");
-            }
+            GlowMask = new($"{Texture}Glow", 18, 18);
         }
 
         public override void SetStaticDefaults()
@@ -63,12 +60,6 @@ namespace CalamityMod.Tiles
 
             DustType = DustID.PlanteraBulb;
             HitSound = SoundID.Grass;
-        }
-
-        public override void Unload()
-        {
-            // Textures are auto disposed by tModLoader, all we need to do is get rid of the asset wrapper reference
-            Glow = null;
         }
 
         // Use the second map entry in Hardmode
@@ -205,12 +196,18 @@ namespace CalamityMod.Tiles
         {
             var tile = Main.tile[i, j];
 
-            spriteBatch.Draw(
-                Glow.Value,
-                new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + CalamityUtils.TileDrawOffset,
-                new Rectangle(tile.TileFrameX, tile.TileFrameY + AnimationFrameHeight * Main.tileFrame[Type], 16, 16),
-                Color.Yellow
-            );
+            var xPos = tile.TileFrameX;
+            var yPos = tile.TileFrameY + AnimationFrameHeight * Main.tileFrame[Type];
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                spriteBatch.Draw(
+                    GlowMask.Texture,
+                    new Vector2(i * 16, j * 16 + 2) - Main.screenPosition + CalamityUtils.TileDrawOffset,
+                    new Rectangle(xPos, yPos, 16, 16),
+                    Color.Yellow
+                );
+            }
         }
     }
 }

--- a/Tiles/Ores/AuricOre.cs
+++ b/Tiles/Ores/AuricOre.cs
@@ -18,13 +18,14 @@ namespace CalamityMod.Tiles.Ores
     {
         public static readonly SoundStyle MineSound = new("CalamityMod/Sounds/Custom/AuricMine", 3);
         public static bool Animate;
-        internal static Texture2D GlowTexture;
+
+        internal static FramedGlowMask GlowMask;
 
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/Ores/AuricOreGlow", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/Ores/AuricOreGlow", 18, 18);
+
             AnimationFrameHeight = 90;
             Main.tileLighted[Type] = true;
             Main.tileSolid[Type] = true;
@@ -88,13 +89,16 @@ namespace CalamityMod.Tiles.Ores
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY + AnimationFrameHeight * Main.tileFrame[Type];
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/Ores/AuricOreGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(225, 255, 255, 255));
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(225, 255, 255, 255));
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/Ores/PerennialOre.cs
+++ b/Tiles/Ores/PerennialOre.cs
@@ -13,12 +13,12 @@ namespace CalamityMod.Tiles.Ores
 {
     public class PerennialOre : ModTile
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            if (!Main.dedServ)
-                GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Tiles/Ores/PerennialOreGlow", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Tiles/Ores/PerennialOreGlow", 18, 18);
+
             Main.tileLighted[Type] = true;
             Main.tileSolid[Type] = true;
             Main.tileMergeDirt[Type] = true;
@@ -195,7 +195,7 @@ namespace CalamityMod.Tiles.Ores
 
         public override void PostDraw(int i, int j, SpriteBatch spriteBatch)
         {
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             int xPos = Main.tile[i, j].TileFrameX;
@@ -289,11 +289,15 @@ namespace CalamityMod.Tiles.Ores
 
             xOffset *= 234;
             xPos += xOffset;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(175, 175, 175, 175));
-            Tile trackTile = Main.tile[i, j];
-            TileFraming.SlopedGlowmask(i, j, 0, GlowTexture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(175, 175, 175, 175));
+                Tile trackTile = Main.tile[i, j];
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Tiles/Ores/ScoriaOre.cs
+++ b/Tiles/Ores/ScoriaOre.cs
@@ -14,8 +14,12 @@ namespace CalamityMod.Tiles.Ores
     [LegacyName("ChaoticOre")]
     public class ScoriaOre : ModTile
     {
+        internal static FramedGlowMask GlowMask;
+
         public override void SetStaticDefaults()
         {
+            GlowMask = new("CalamityMod/Tiles/Ores/ScoriaOreGlow", 18, 18);
+
             Main.tileLighted[Type] = true;
             Main.tileSolid[Type] = true;
             Main.tileBlockLight[Type] = true;
@@ -91,13 +95,16 @@ namespace CalamityMod.Tiles.Ores
         {
             int xPos = Main.tile[i, j].TileFrameX;
             int yPos = Main.tile[i, j].TileFrameY;
-            Texture2D glowmask = ModContent.Request<Texture2D>("CalamityMod/Tiles/Ores/ScoriaOreGlow").Value;
-            Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
-            Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
-            Color drawColour = GetDrawColour(i, j, new Color(50, 50, 50, 50));
-            Tile trackTile = Main.tile[i, j];
-            double num6 = Main.time * 0.08;
-            TileFraming.SlopedGlowmask(i, j, 0, glowmask, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
+            {
+                Vector2 zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);
+                Vector2 drawOffset = new Vector2(i * 16 - Main.screenPosition.X, j * 16 - Main.screenPosition.Y) + zero;
+                Color drawColour = GetDrawColour(i, j, new Color(50, 50, 50, 50));
+                Tile trackTile = Main.tile[i, j];
+                double num6 = Main.time * 0.08;
+                TileFraming.SlopedGlowmask(i, j, 0, GlowMask.Texture, drawOffset, null, GetDrawColour(i, j, drawColour), default);
+            }
         }
 
         private Color GetDrawColour(int i, int j, Color colour)

--- a/Utilities/FramedGlowMask.cs
+++ b/Utilities/FramedGlowMask.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using Terraria;
+using Terraria.ModLoader;
+
+namespace CalamityMod
+{
+    public sealed class FramedGlowMask
+    {
+        /// <summary>
+        /// Cached Texture2D reference, null on server
+        /// </summary>
+        public Texture2D Texture { get; private set; }
+        
+        /// <summary>
+        /// X axis's frame count, 0 on server
+        /// </summary>
+        public int FrameXCount { get; private set; } = 0;
+
+        /// <summary>
+        /// Y axis's frame count, 0 on server
+        /// </summary>
+        public int FrameYCount { get; private set; } = 0;
+        
+        /// <summary>
+        /// Pixel width for each frame
+        /// </summary>
+        public int FrameWidth { get; private set; }
+
+        /// <summary>
+        /// Pixel height for each frame
+        /// </summary>
+        public int FrameHeight { get; private set; }
+
+        private static event Action _OnUnload;
+        private readonly bool[,] _HasGlowContent;
+
+        internal static void UnloadTexCache()
+        {
+            _OnUnload?.Invoke();
+        }
+
+        public FramedGlowMask(string asset, int frameWidth, int frameHeight, bool pretendEveryFrameHaveGlow = false)
+        {
+            FrameWidth = frameWidth;
+            FrameHeight = frameHeight;
+
+            // Don't do anything further on server
+            if (Main.dedServ)
+                return;
+
+            Texture = ModContent.Request<Texture2D>(asset, AssetRequestMode.ImmediateLoad).Value;
+            if (Texture is null)
+                return;
+
+            _OnUnload += () =>
+            {
+                Texture = null;
+                FrameWidth = 0;
+                FrameHeight = 0;
+                FrameXCount = 0;
+                FrameYCount = 0;
+            };
+
+            FrameXCount = Texture.Width / frameWidth;
+            FrameYCount = Texture.Height / frameHeight;
+
+            _HasGlowContent = new bool[FrameXCount, FrameYCount];
+
+            
+            if (pretendEveryFrameHaveGlow)
+            {
+                for(int x = 0; x<FrameXCount; x++)
+                {
+                    for (int y = 0; y<FrameYCount; y++)
+                    {
+                        _HasGlowContent[x, y] = true;
+                    }
+                }
+            }
+            else
+            {
+                Main.QueueMainThreadAction(() =>
+                {
+                    var colData = Texture.GetColorsFromTexture();
+                    Parallel.For(0, FrameXCount * FrameYCount, (i) =>
+                    {
+                        int xFrame = i % FrameXCount;
+                        int yFrame = i / FrameXCount;
+
+                        int xStart = xFrame * frameWidth;
+                        int xEnd = xStart + frameWidth;
+
+                        int yStart = yFrame * frameHeight;
+                        int yEnd = yStart + frameHeight;
+
+                        bool frameHasData = false;
+                        for (int x = xStart; x < xEnd; x++)
+                        {
+                            if (frameHasData)
+                            {
+                                break;
+                            }
+
+                            for (int y = yStart; y < yEnd; y++)
+                            {
+                                Color col = colData[x, y];
+                                if (col.A >= 1)
+                                {
+                                    frameHasData = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        _HasGlowContent[xFrame, yFrame] = frameHasData;
+                    });
+                });
+            }
+        }
+
+        public bool HasContentInFrameIndex(int xFrame, int yFrame)
+        {
+            if (Texture is null)
+                return false;
+
+            return _HasGlowContent[xFrame, yFrame];
+        }
+
+        public bool HasContentInFramePos(int xPos, int yPos)
+        {
+            if (Texture is null)
+                return false;
+
+            return _HasGlowContent[xPos / FrameWidth, yPos / FrameHeight];
+        }
+    }
+}

--- a/Walls/VoidstoneWall.cs
+++ b/Walls/VoidstoneWall.cs
@@ -11,13 +11,13 @@ namespace CalamityMod.Walls
 {
     public class VoidstoneWall : ModWall
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            Main.wallHouse[Type] = true;
-            GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Walls/VoidstoneWall_Glowmask", AssetRequestMode.ImmediateLoad).Value;
+            GlowMask = new("CalamityMod/Walls/VoidstoneWall_Glowmask", 36, 36);
 
+            Main.wallHouse[Type] = true;
             AddMapEntry(new Color(0, 0, 0));
         }
 
@@ -29,37 +29,44 @@ namespace CalamityMod.Walls
 
         public static void DrawWallGlow(int wallType, int i, int j, SpriteBatch spriteBatch)
         {
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             Tile tile = Main.tile[i, j];
             int xLength = 32;
             int xOff = 0;
 
-            Rectangle frame = new Rectangle(tile.WallFrameX + xOff, tile.WallFrameY, xLength, 32);
+            int xPos = tile.WallFrameX + xOff;
+            int yPos = tile.WallFrameY;
+
+            Rectangle frame = new Rectangle(xPos, yPos, xLength, 32);
             Color drawcolor;
             drawcolor = WorldGen.paintColor(tile.WallColor);
             drawcolor.A = 255;
             Vector2 zero = new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            float brightness = 1f;
-            float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
-            brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            drawcolor *= brightness;
-
             if (Main.drawToScreen)
                 zero = Vector2.Zero;
 
             Vector2 pos = new Vector2(i * 16 - (int)Main.screenPosition.X, j * 16 - (int)Main.screenPosition.Y) + zero;
-            Main.spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
-            Color glowColor = drawcolor * 0.4f;
-            for (int k = 0; k < 3; k++)
+            spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
             {
-                Vector2 offset = new Vector2(Main.rand.NextFloat(-1, 1f), Main.rand.NextFloat(-1, 1f)) * 0.2f * k;
-                Main.spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                float brightness = 1f;
+                float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
+                brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                drawcolor *= brightness;
+                Color glowColor = drawcolor * 0.4f;
+
+                for (int k = 0; k < 3; k++)
+                {
+                    Vector2 offset = new Vector2(Main.rand.NextFloat(-1, 1f), Main.rand.NextFloat(-1, 1f)) * 0.2f * k;
+                    spriteBatch.Draw(GlowMask.Texture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                }
             }
         }
 

--- a/Walls/VoidstoneWallUnsafe.cs
+++ b/Walls/VoidstoneWallUnsafe.cs
@@ -11,11 +11,14 @@ namespace CalamityMod.Walls
 {
     public class VoidstoneWallUnsafe : ModWall
     {
-        internal static Texture2D GlowTexture;
+        internal static FramedGlowMask GlowMask;
 
         public override void SetStaticDefaults()
         {
-            GlowTexture = ModContent.Request<Texture2D>("CalamityMod/Walls/VoidstoneWall_Glowmask", AssetRequestMode.ImmediateLoad).Value;
+            // We basically have same copy in VoidstoneWall
+            // But leaving this in case of changing to Unsafe variant specific glowmask
+            GlowMask = new("CalamityMod/Walls/VoidstoneWall_Glowmask", 36, 36);
+
             DustType = 187;
             AddMapEntry(new Color(0, 0, 0));
         }
@@ -34,37 +37,46 @@ namespace CalamityMod.Walls
 
         public static void DrawWallGlow(int wallType, int i, int j, SpriteBatch spriteBatch)
         {
-            if (GlowTexture is null)
+            if (GlowMask.Texture is null)
                 return;
 
             Tile tile = Main.tile[i, j];
             int xLength = 32;
             int xOff = 0;
 
-            Rectangle frame = new Rectangle(tile.WallFrameX + xOff, tile.WallFrameY, xLength, 32);
+            int xPos = tile.WallFrameX + xOff;
+            int yPos = tile.WallFrameY;
+
+            Rectangle frame = new Rectangle(xPos, yPos, xLength, 32);
             Color drawcolor;
             drawcolor = WorldGen.paintColor(tile.WallColor);
             drawcolor.A = 255;
             Vector2 zero = new Vector2(Main.offScreenRange, Main.offScreenRange);
 
-            float brightness = 1f;
-            float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
-            brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
-            drawcolor *= brightness;
-
             if (Main.drawToScreen)
                 zero = Vector2.Zero;
 
             Vector2 pos = new Vector2((i * 16 - (int)Main.screenPosition.X), (j * 16 - (int)Main.screenPosition.Y)) + zero;
-            Main.spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
-            Color glowColor = drawcolor * 0.4f;
-            for (int k = 0; k < 3; k++)
+            spriteBatch.Draw(TextureAssets.Wall[wallType].Value, pos + new Vector2(-8 + xOff, -8), frame, Lighting.GetColor(i, j, Color.White), 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+
+            if (GlowMask.HasContentInFramePos(xPos, yPos))
             {
-                Vector2 offset = new Vector2(Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-1f, 1f)) * 0.2f * k;
-                Main.spriteBatch.Draw(GlowTexture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                float brightness = 1f;
+                float declareThisHereToPreventRunningTheSameCalculationMultipleTimes = Main.GameUpdateCount * 0.007f;
+                brightness *= (float)MathF.Sin(i / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j / 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(i * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                brightness *= (float)MathF.Sin(j * 18f + declareThisHereToPreventRunningTheSameCalculationMultipleTimes);
+                drawcolor *= brightness;
+                Color glowColor = drawcolor * 0.4f;
+
+                // For now checking for glowing frames greatly reducing the bottleneck
+                // But maybe we could squeeze bit more by removing the loop
+                for (int k = 0; k < 3; k++)
+                {
+                    Vector2 offset = new Vector2(Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-1f, 1f)) * 0.2f * k;
+                    spriteBatch.Draw(GlowMask.Texture, pos + offset + new Vector2(-8 + xOff, -8), frame, glowColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+                }
             }
         }
 


### PR DESCRIPTION
# Fixing for:
- Abyss Hazards tiles always calculate for their projectile whether they actually spawn one or not
- GlowMask tile/walls are always draw Glow layer even if they are empty in GlowMask sheet
  - Note: `VoidstoneWall`, `VoidstoneUnsafeWall` were critically impacting performance on Abyss Layer 4

# Quick GlowMask fix performance comparison
| Abyss L4 Before       | Abyss L4 After       |
|-----------------------|----------------------|
|  ![before_abyss_layer4](https://github.com/user-attachments/assets/16b35c92-4ecc-49fb-be3f-e04aad91d985)  |   ![after_abyss_layer4](https://github.com/user-attachments/assets/2b5f152a-cce8-42e5-82ab-0af6341dc042)  |
| Profand Garden Before | Profand Garden After |
| ![before_profand_garden](https://github.com/user-attachments/assets/41be817f-a7f2-487e-9ea4-fb9f5dcb640d)    |   ![after_profand_garden](https://github.com/user-attachments/assets/4819baaa-3786-45c9-bf48-f57d62f04020)   |