### PR TITLE
Fixed MP Issue on ClimateChange/Invasion Items

### DIFF
--- a/Items/SummonItems/Invasion/CausticTear.cs
+++ b/Items/SummonItems/Invasion/CausticTear.cs
@@ -42,7 +42,7 @@ namespace CalamityMod.Items.SummonItems.Invasion
             if (Main.netMode != NetmodeID.MultiplayerClient)
             {
                 AcidRainEvent.TryStartEvent(forceRain: true);
-                //CalamityNetcode.SyncWorld(); //TryStartEvent(forceRain: true) already sync the world data
+                // TryStartEvent already syncs the world data
             }
 
             return true;

--- a/Items/SummonItems/Invasion/CausticTear.cs
+++ b/Items/SummonItems/Invasion/CausticTear.cs
@@ -38,8 +38,13 @@ namespace CalamityMod.Items.SummonItems.Invasion
 
         public override bool? UseItem(Player player)
         {
-            AcidRainEvent.TryStartEvent(forceRain: true);
-            //CalamityNetcode.SyncWorld(); //TryStartEvent(forceRain: true) already sync the world data
+            // Only Single Player client and Server should call this!
+            if (Main.netMode != NetmodeID.MultiplayerClient)
+            {
+                AcidRainEvent.TryStartEvent(forceRain: true);
+                //CalamityNetcode.SyncWorld(); //TryStartEvent(forceRain: true) already sync the world data
+            }
+
             return true;
         }
 

--- a/Items/Tools/ClimateChange/AridArtifact.cs
+++ b/Items/Tools/ClimateChange/AridArtifact.cs
@@ -1,8 +1,13 @@
 ﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+
+using SandstormEvent = Terraria.GameContent.Events.Sandstorm;
+
 namespace CalamityMod.Items.Tools.ClimateChange
 {
+    
+
     public class AridArtifact : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Tools";
@@ -27,13 +32,17 @@ namespace CalamityMod.Items.Tools.ClimateChange
             return DownedBossSystem.downedDesertScourge || Main.hardMode;
         }
 
-        // this is extremely ugly and has to be fully qualified because we add an item called Sandstorm
         public override bool? UseItem(Player player)
         {
-            if (Terraria.GameContent.Events.Sandstorm.Happening)
+            // Only SinglePlayer and Server need to sync those parameters
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                return true;
+
+            if (SandstormEvent.Happening)
                 CalamityUtils.StopSandstorm();
             else
                 CalamityUtils.StartSandstorm();
+
             return true;
         }
 

--- a/Items/Tools/ClimateChange/Cosmolight.cs
+++ b/Items/Tools/ClimateChange/Cosmolight.cs
@@ -32,16 +32,13 @@ namespace CalamityMod.Items.Tools.ClimateChange
             itemGroup = (ContentSamples.CreativeHelper.ItemGroup)CalamityResearchSorting.ToolsOther;
         }
 
-        public override bool CanUseItem(Player player)
+        public override bool CanUseItem(Player player) => !CalamityPlayer.areThereAnyDamnBosses;
+
+        public override bool? UseItem(Player player)
         {
             //Only SinglePlayer or DedServ should change time to prevent unwanted race condition
             if (Main.netMode == NetmodeID.MultiplayerClient)
                 return true;
-
-            if (CalamityPlayer.areThereAnyDamnBosses)
-                return false;
-
-
 
             // Early Morning -> Noon
             if (Main.dayTime && Main.time < NoonCutoff)

--- a/Items/Tools/ClimateChange/TorrentialTear.cs
+++ b/Items/Tools/ClimateChange/TorrentialTear.cs
@@ -31,16 +31,19 @@ namespace CalamityMod.Items.Tools.ClimateChange
 
         public override bool? UseItem(Player player)
         {
+            // Only SinglePlayer and Server need to sync those parameters
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                return true;
+
             if (!Main.raining)
             {
-                CalamityUtils.StartRain(true);
+                CalamityUtils.StartRain(torrentialTear: true, worldSync: true);
             }
             else
             {
-                Main.raining = false;
+                CalamityUtils.StopRain(clearWeather: false, worldSync: true);
             }
 
-            CalamityNetcode.SyncWorld();
             return true;
         }
 

--- a/Utilities/MiscUtils.cs
+++ b/Utilities/MiscUtils.cs
@@ -195,7 +195,7 @@ namespace CalamityMod
             sfx.Volume = MathHelper.Clamp(sfx.Volume * volumeMultiplier, 0f, 1f);
         }
 
-        public static void StartRain(bool torrentialTear = false, bool maxSeverity = false)
+        public static void StartRain(bool torrentialTear = false, bool maxSeverity = false, bool worldSync = true)
         {
             int framesInDay = 86400;
             int framesInHour = framesInDay / 24;
@@ -245,7 +245,20 @@ namespace CalamityMod
             Main.raining = true;
             if (torrentialTear)
                 TorrentialTear.AdjustRainSeverity(maxSeverity);
-            CalamityNetcode.SyncWorld();
+
+            if (worldSync)
+                CalamityNetcode.SyncWorld();
+        }
+
+        public static void StopRain(bool clearWeather = false, bool worldSync = true)
+        {
+            if (clearWeather)
+                Main.StopRain();
+            else
+                Main.raining = false;
+            
+            if (worldSync)
+                CalamityNetcode.SyncWorld();
         }
 
         public static void StartSandstorm()

--- a/Utilities/MiscUtils.cs
+++ b/Utilities/MiscUtils.cs
@@ -277,7 +277,10 @@ namespace CalamityMod
 
         public static void StopSandstorm()
         {
-            Terraria.GameContent.Events.Sandstorm.Happening = false;
+            if (Main.netMode != NetmodeID.MultiplayerClient)
+            {
+                Sandstorm.StopSandstorm();
+            }
         }
 
         public static void AddWithCondition<T>(this List<T> list, T type, bool condition)


### PR DESCRIPTION
- `Torrential Tear`: Removed duplicated WorldSync
- `Cosmolight`: Use Animation can be played even if boss is alive on MP
- `Martian Remote`:
  - Fixed packet spam issue (Removed: Non-owner-client -> server,   server -> client)
  - Added Invasion condition check where at least one player should consumed 5 life crystal (niche situation but it still bugs out the GUI when it happens)
- `Arid Artifact`: Now able to turn off the Sandstorm in MP
- `Caustic Tear`: Fixed Issue where `A toxic downpour falls over the wasteland seas!` message appear multiple times