### PR TITLE
Bandit now do refunds in Multiplayer properly

### DIFF
--- a/Items/CalamityGlobalItem.cs
+++ b/Items/CalamityGlobalItem.cs
@@ -1808,11 +1808,21 @@ namespace CalamityMod.Items
                 ItemLoader.ReforgePrice(item, ref value, ref p.discountAvailable);
 
                 // Steal 20% of that money.
-                CalamityWorld.MoneyStolenByBandit += value / 5;
+                int stolen = value / 5;
+                CalamityWorld.MoneyStolenByBandit += stolen;
 
                 // Increment the reforge counter to allow the Bandit to refund
                 // Also triggers Tinkerer dialogue that hints to the player that money is being stolen
                 CalamityWorld.Reforges++;
+
+                if (Main.netMode == NetmodeID.MultiplayerClient)
+                {
+                    ModPacket packet = CalamityMod.Instance.GetPacket();
+                    packet.Write((byte)CalamityModMessageType.SomeoneGotScammedByTinkerer);
+                    packet.Write((byte)p.whoAmI);
+                    packet.Write7BitEncodedInt(stolen);
+                    packet.Send();
+                }
             }
         }
         #endregion


### PR DESCRIPTION
Fixed Issue where Bandit cannot properly steal money from Goblin in Multiplayer

# Note:
- Current Implementation have text bug when multiple players click `Refund` button which is minor and doesn't induce any money duplication glitch or something. (Also mentioned as comment)
- Bandit stolen amount is shared between player, So only the first one talked to bandit can get refund including others sharing (It kind of makes sense for me but worth to mention here)