### PR TITLE
SuperDummy QoL: Allow to Right-click on Inventory

### DIFF
--- a/Items/AntiCystOintment.cs
+++ b/Items/AntiCystOintment.cs
@@ -33,13 +33,9 @@ namespace CalamityMod.Items
                 player.Calamity().disablePerfCystSpawns = false;
             else
                 player.Calamity().disablePerfCystSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().disablePerfCystSpawns;
 
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<AntiCystOintment>());
-            Item.stack++;
-            Item.favorited = favorited;
+            Item.RestoreConsumedItemByRightClick();
         }
 
         /*

--- a/Items/AntiTumorOintment.cs
+++ b/Items/AntiTumorOintment.cs
@@ -33,13 +33,9 @@ namespace CalamityMod.Items
                 player.Calamity().disableHiveCystSpawns = false;
             else
                 player.Calamity().disableHiveCystSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().disableHiveCystSpawns;
 
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<AntiTumorOintment>());
-            Item.stack++;
-            Item.favorited = favorited;
+            Item.RestoreConsumedItemByRightClick();
         }
         /*
         public override bool PreDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frameI, Color drawColor, Color itemColor, Vector2 origin, float scale)

--- a/Items/BleachBall.cs
+++ b/Items/BleachBall.cs
@@ -34,13 +34,9 @@ namespace CalamityMod.Items
                 player.Calamity().disableNaturalScourgeSpawns = false;
             else
                 player.Calamity().disableNaturalScourgeSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().disableNaturalScourgeSpawns;
 
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<BleachBall>());
-            Item.stack++;
-            Item.favorited = favorited;
+            Item.RestoreConsumedItemByRightClick();
         }
 
         /*

--- a/Items/BrokenWaterFilter.cs
+++ b/Items/BrokenWaterFilter.cs
@@ -34,13 +34,9 @@ namespace CalamityMod.Items
                 player.Calamity().noStupidNaturalARSpawns = false;
             else
                 player.Calamity().noStupidNaturalARSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().noStupidNaturalARSpawns;
 
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<BrokenWaterFilter>());
-            Item.stack++;
-            Item.favorited = favorited;
+            Item.RestoreConsumedItemByRightClick();
         }
 
         /*

--- a/Items/SirenproofEarMuffs.cs
+++ b/Items/SirenproofEarMuffs.cs
@@ -34,13 +34,9 @@ namespace CalamityMod.Items
                 player.Calamity().disableAnahitaSpawns = false;
             else
                 player.Calamity().disableAnahitaSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().disableAnahitaSpawns;
 
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<SirenproofEarMuffs>());
-            Item.stack++;
-            Item.favorited = favorited;
+            Item.RestoreConsumedItemByRightClick();
         }
 
         /*

--- a/Items/SuperDummy.cs
+++ b/Items/SuperDummy.cs
@@ -87,6 +87,25 @@ namespace CalamityMod.Items
             return true;
         }
 
+        public override bool CanRightClick() => true;
+
+        // RightClick only called by client, no worry about potential packetstorm
+        public override void RightClick(Player player)
+        {
+            if (Main.netMode == NetmodeID.SinglePlayer)
+            {
+                DeleteDummies();
+            }
+            else
+            {
+                var netMessage = Mod.GetPacket();
+                netMessage.Write((byte)CalamityModMessageType.DeleteAllSuperDummies);
+                netMessage.Send();
+            }
+
+            Item.RestoreConsumedItemByRightClick();
+        }
+
         public override void AddRecipes()
         {
             Recipe r = CreateRecipe();

--- a/Items/VoodooDemonVoodooDoll.cs
+++ b/Items/VoodooDemonVoodooDoll.cs
@@ -35,12 +35,9 @@ namespace CalamityMod.Items
                 player.Calamity().disableVoodooSpawns = false;
             else
                 player.Calamity().disableVoodooSpawns = true;
-            Item.NetStateChanged();
             state = player.Calamity().disableVoodooSpawns;
-            bool favorited = Item.favorited;
-            Item.SetDefaults(ModContent.ItemType<VoodooDemonVoodooDoll>());
-            Item.stack++;
-            Item.favorited = favorited;       
+
+            Item.RestoreConsumedItemByRightClick();
         }
 
         /*

--- a/Utilities/ItemUtils.cs
+++ b/Utilities/ItemUtils.cs
@@ -749,6 +749,15 @@ namespace CalamityMod
             }
         }
 
+        public static void RestoreConsumedItemByRightClick(this Item item)
+        {
+            bool favorited = item.favorited;
+            item.SetDefaults(item.type);
+            item.stack++;
+            item.favorited = favorited;
+            item.NetStateChanged();
+        }
+
         #region Rogue Prefixes
         public static int RandomRoguePrefix()
         {


### PR DESCRIPTION
SuperDummy now can be Right-click on Inventory to delete dummies

This could improve QoL by allowing players to Inventory click to spawn dummy and right click to delete, So it no longer require to be in hotbar if they want

![dummy-rightclick-test](https://github.com/user-attachments/assets/70b613d3-88e1-4ad7-9481-256fc5e38f6e)

This PR also Including simplified shortcut util for Right-click base item: (can be applied to spawn blocker items and already did)
```cs
public static void RestoreConsumedItemByRightClick(this Item item)
{
    bool favorited = item.favorited;
    item.SetDefaults(item.type);
    item.stack++;
    item.favorited = favorited;
    item.NetStateChanged();
}
```