### PR TITLE
Netcode Fix: Boss Summon Item issue fixes

### DIFF
--- a/Items/SummonItems/Abombination.cs
+++ b/Items/SummonItems/Abombination.cs
@@ -41,12 +41,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(UseSound, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<PlaguebringerGoliath>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<PlaguebringerGoliath>());
-
+            CalamityUtils.SpawnBossUsingItem<PlaguebringerGoliath>(player, UseSound);
             return true;
         }
 

--- a/Items/SummonItems/AstralChunk.cs
+++ b/Items/SummonItems/AstralChunk.cs
@@ -2,8 +2,6 @@
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.AstrumAureus;
 using Terraria;
-using Terraria.Audio;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -40,16 +38,10 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                int npc = NPC.NewNPC(new EntitySource_BossSpawn(player), (int)(player.position.X + Main.rand.Next(-250, 251)), (int)(player.position.Y - 500f), ModContent.NPCType<AstrumAureus>(), 1);
-                Main.npc[npc].timeLeft *= 20;
-                CalamityUtils.BossAwakenMessage(npc);
-            }
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<AstrumAureus>());
-
+            int posX = (int)(player.position.X + Main.rand.Next(-250, 251));
+            int posY = (int)(player.position.Y - 500f);
+            int bossToSpawn = ModContent.NPCType<AstrumAureus>();
+            CalamityUtils.SpawnBossOnPosUsingItem(player, bossToSpawn, posX, posY, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/BloodyWormFood.cs
+++ b/Items/SummonItems/BloodyWormFood.cs
@@ -2,7 +2,6 @@
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.Perforator;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -39,12 +38,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<PerforatorHive>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<PerforatorHive>());
-
+            CalamityUtils.SpawnBossUsingItem<PerforatorHive>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/CharredIdol.cs
+++ b/Items/SummonItems/CharredIdol.cs
@@ -3,7 +3,6 @@ using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.BrimstoneElemental;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -41,12 +40,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<BrimstoneElemental>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<BrimstoneElemental>());
-
+            CalamityUtils.SpawnBossUsingItem<BrimstoneElemental>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/CosmicWorm.cs
+++ b/Items/SummonItems/CosmicWorm.cs
@@ -4,7 +4,6 @@ using CalamityMod.NPCs.DevourerofGods;
 using CalamityMod.Rarities;
 using Microsoft.Xna.Framework;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -45,12 +44,7 @@ namespace CalamityMod.Items.SummonItems
             Color messageColor = Color.Cyan;
             CalamityUtils.DisplayLocalizedText(key, messageColor);
 
-            SoundEngine.PlaySound(DevourerofGodsHead.SpawnSound, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<DevourerofGodsHead>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<DevourerofGodsHead>());
-
+            CalamityUtils.SpawnBossUsingItem<DevourerofGodsHead>(player, DevourerofGodsHead.SpawnSound);
             return true;
         }
 

--- a/Items/SummonItems/CryoKey.cs
+++ b/Items/SummonItems/CryoKey.cs
@@ -3,11 +3,9 @@ using System.Linq;
 using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.Cryogen;
-using CalamityMod.World;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -43,12 +41,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Cryogen>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Cryogen>());
-
+            CalamityUtils.SpawnBossUsingItem<Cryogen>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/DeathWhistle.cs
+++ b/Items/SummonItems/DeathWhistle.cs
@@ -40,16 +40,10 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.ScaryScream, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                int npc = NPC.NewNPC(new EntitySource_BossSpawn(player), (int)(player.position.X + Main.rand.Next(-250, 251)), (int)(player.position.Y - 500f), ModContent.NPCType<RavagerBody>(), 1);
-                Main.npc[npc].timeLeft *= 20;
-                CalamityUtils.BossAwakenMessage(npc);
-            }
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<RavagerBody>());
-
+            int posX = (int)(player.position.X + Main.rand.Next(-250, 251));
+            int posY = (int)(player.position.Y - 500f);
+            int bossToSpawn = ModContent.NPCType<RavagerBody>();
+            CalamityUtils.SpawnBossOnPosUsingItem(player, bossToSpawn, posX, posY, SoundID.ScaryScream);
             return true;
         }
 

--- a/Items/SummonItems/DecapoditaSprout.cs
+++ b/Items/SummonItems/DecapoditaSprout.cs
@@ -1,8 +1,6 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.NPCs.Crabulon;
 using Terraria;
-using Terraria.Audio;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -39,16 +37,9 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                int npc = NPC.NewNPC(new EntitySource_BossSpawn(player), (int)(player.position.X + Main.rand.Next(-160, 161)), (int)(player.position.Y - 320f), ModContent.NPCType<Crabulon>(), 1);
-                Main.npc[npc].timeLeft *= 20;
-                CalamityUtils.BossAwakenMessage(npc);
-            }
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Crabulon>());
-
+            int posX = (int)(player.position.X + Main.rand.Next(-160, 161));
+            int posY = (int)(player.position.Y - 320f);
+            CalamityUtils.SpawnBossOnPosUsingItem<Crabulon>(player, posX, posY, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/DesertMedallion.cs
+++ b/Items/SummonItems/DesertMedallion.cs
@@ -1,9 +1,7 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.DesertScourge;
-using CalamityMod.World;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -41,12 +39,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<DesertScourgeHead>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<DesertScourgeHead>());
-
+            CalamityUtils.SpawnBossUsingItem<DesertScourgeHead>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/EidolonTablet.cs
+++ b/Items/SummonItems/EidolonTablet.cs
@@ -41,12 +41,9 @@ namespace CalamityMod.Items.SummonItems
             if (NPC.MoonLordCountdown > 0)
                 return false;
 
-            for(int i = 0; i<200; i++)
+            foreach (var npc in Main.ActiveNPCs)
             {
-                if (!Main.npc[i].active)
-                    continue;
-
-                switch (Main.npc[i].type)
+                switch (npc.type)
                 {
                     case NPCID.CultistTablet:
                     case NPCID.CultistBoss:

--- a/Items/SummonItems/EidolonTablet.cs
+++ b/Items/SummonItems/EidolonTablet.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using CalamityMod.Events;
 using Terraria;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -34,21 +33,48 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool CanUseItem(Player player)
         {
-            return !NPC.AnyNPCs(NPCID.CultistBoss) && !NPC.LunarApocalypseIsUp && !NPC.AnyNPCs(NPCID.CultistTablet) && !BossRushEvent.BossRushActive;
+            // This is quite ugly, but MP does not sync NPC.LunarApocalypseIsUp
+            // So we should check it ourselves
+            if (BossRushEvent.BossRushActive)
+                return false;
+
+            if (NPC.MoonLordCountdown > 0)
+                return false;
+
+            for(int i = 0; i<200; i++)
+            {
+                if (!Main.npc[i].active)
+                    continue;
+
+                switch (Main.npc[i].type)
+                {
+                    case NPCID.CultistTablet:
+                    case NPCID.CultistBoss:
+                    case NPCID.LunarTowerSolar:
+                    case NPCID.LunarTowerVortex:
+                    case NPCID.LunarTowerNebula:
+                    case NPCID.LunarTowerStardust:
+                    case NPCID.MoonLordCore:
+                        return false;
+                }
+            }
+
+            return true;
         }
 
         public override bool? UseItem(Player player)
         {
-            if (Main.netMode != NetmodeID.MultiplayerClient)
+            int posX = (int)player.Center.X + 30;
+            int posY = (int)player.Center.Y - 90;
+            NPC npc = CalamityUtils.SpawnBossOnPosUsingItem(player, NPCID.CultistBoss, posX, posY);
+            if (npc != null)
             {
-                int npc = NPC.NewNPC(new EntitySource_BossSpawn(player), (int)player.Center.X + 30, (int)player.Center.Y - 90, NPCID.CultistBoss, 1);
-                Main.npc[npc].direction = Main.npc[npc].spriteDirection = Math.Sign(player.Center.X - player.Center.X - 30f);
-                Main.npc[npc].timeLeft *= 20;
-                CalamityUtils.BossAwakenMessage(npc);
-            }
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, NPCID.CultistBoss);
+                WorldGen.GetRidOfCultists();
 
+                int newDir = Math.Sign(player.Center.X - player.Center.X - 30f);
+                npc.direction = newDir;
+                npc.spriteDirection = newDir;
+            }
             return true;
         }
     }

--- a/Items/SummonItems/ExoticPheromones.cs
+++ b/Items/SummonItems/ExoticPheromones.cs
@@ -2,7 +2,6 @@
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.Bumblebirb;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -40,12 +39,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Bumblefuck>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Bumblefuck>());
-
+            CalamityUtils.SpawnBossUsingItem<Bumblefuck>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/EyeofDesolation.cs
+++ b/Items/SummonItems/EyeofDesolation.cs
@@ -2,10 +2,8 @@
 using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.CalClone;
-using CalamityMod.World;
 using Microsoft.Xna.Framework;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -52,11 +50,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<CalamitasClone>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<CalamitasClone>());
+            CalamityUtils.SpawnBossUsingItem<CalamitasClone>(player, SoundID.Roar);
 
             if (Main.netMode != NetmodeID.MultiplayerClient && Main.zenithWorld)
             {

--- a/Items/SummonItems/NO.cs
+++ b/Items/SummonItems/NO.cs
@@ -1,9 +1,7 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.NPCs.Other;
 using CalamityMod.Rarities;
-using Microsoft.Xna.Framework;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -39,11 +37,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<THELORDE>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<THELORDE>());
+            CalamityUtils.SpawnBossUsingItem<THELORDE>(player, SoundID.Roar);
             return true;
         }
     }

--- a/Items/SummonItems/NecroplasmicBeacon.cs
+++ b/Items/SummonItems/NecroplasmicBeacon.cs
@@ -5,7 +5,6 @@ using CalamityMod.Rarities;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -48,12 +47,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(Polterghast.SpawnSound, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Polterghast>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Polterghast>());
-
+            CalamityUtils.SpawnBossUsingItem<Polterghast>(player, Polterghast.SpawnSound);
             return true;
         }
 

--- a/Items/SummonItems/OldPowerCell.cs
+++ b/Items/SummonItems/OldPowerCell.cs
@@ -1,7 +1,6 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -36,26 +35,14 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool CanUseItem(Player player)
         {
-            bool canSummon = false;
-            if (player.Center.Y > Main.worldSurface * 16.0)
-            {
-                int playerTileX = (int)player.Center.X / 16;
-                int playerTileY = (int)player.Center.Y / 16;
-                Tile tile = Framing.GetTileSafely(playerTileX, playerTileY);
-                if (tile.WallType == 87)
-                    canSummon = true;
-            }
-            return canSummon && !NPC.AnyNPCs(NPCID.Golem) && !BossRushEvent.BossRushActive;
+            return player.ZoneLihzhardTemple && !NPC.AnyNPCs(NPCID.Golem) && !BossRushEvent.BossRushActive;
         }
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, NPCID.Golem);
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, NPCID.Golem);
-
+            int posX = (int)player.Center.X;
+            int posY = (int)(player.Center.Y - 150.0f);
+            CalamityUtils.SpawnBossOnPosUsingItem(player, NPCID.Golem, posX, posY, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/OverloadedSludge.cs
+++ b/Items/SummonItems/OverloadedSludge.cs
@@ -2,7 +2,6 @@
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.SlimeGod;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -39,12 +38,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<SlimeGodCore>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<SlimeGodCore>());
-
+            CalamityUtils.SpawnBossUsingItem<SlimeGodCore>(player, SoundID.Roar); 
             return true;
         }
 

--- a/Items/SummonItems/Portabulb.cs
+++ b/Items/SummonItems/Portabulb.cs
@@ -1,7 +1,6 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -40,12 +39,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, NPCID.Plantera);
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, NPCID.Plantera);
-
+            CalamityUtils.SpawnBossUsingItem(player, NPCID.Plantera, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/ProfanedCore.cs
+++ b/Items/SummonItems/ProfanedCore.cs
@@ -1,8 +1,6 @@
 ﻿using CalamityMod.Events;
 using CalamityMod.NPCs.Providence;
 using Terraria;
-using Terraria.Audio;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -40,16 +38,10 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(Providence.SpawnSound, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                int npc = NPC.NewNPC(new EntitySource_BossSpawn(player), (int)(player.position.X + Main.rand.Next(-500, 501)), (int)(player.position.Y - 250f), ModContent.NPCType<Providence>(), 1);
-                Main.npc[npc].timeLeft *= 20;
-                CalamityUtils.BossAwakenMessage(npc);
-            }
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Providence>());
-
+            int posX = (int)(player.position.X + Main.rand.Next(-500, 501));
+            int posY = (int)(player.position.Y - 250f);
+            int bossToSpawn = ModContent.NPCType<Providence>();
+            CalamityUtils.SpawnBossOnPosUsingItem(player, bossToSpawn, posX, posY, Providence.SpawnSound);
             return true;
         }
     }

--- a/Items/SummonItems/ProfanedShard.cs
+++ b/Items/SummonItems/ProfanedShard.cs
@@ -2,9 +2,7 @@
 using CalamityMod.Events;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.ProfanedGuardians;
-using CalamityMod.World;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -41,12 +39,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<ProfanedGuardianCommander>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<ProfanedGuardianCommander>());
-
+            CalamityUtils.SpawnBossUsingItem<ProfanedGuardianCommander>(player, SoundID.Roar);
             return true;
         }
         public override void ModifyTooltips(List<TooltipLine> list) => list.FindAndReplace("[SPAWN]", this.GetLocalizedValue(Main.remixWorld ? "SpawnRemix" : "SpawnNormal"));

--- a/Items/SummonItems/RuneofKos.cs
+++ b/Items/SummonItems/RuneofKos.cs
@@ -51,27 +51,15 @@ namespace CalamityMod.Items.SummonItems
         {
             if (player.ZoneDungeon)
             {
-                SoundEngine.PlaySound(CVSound, player.Center);
-                if (Main.netMode != NetmodeID.MultiplayerClient)
-                    NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<CeaselessVoid>());
-                else
-                    NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<CeaselessVoid>());
+                CalamityUtils.SpawnBossUsingItem<CeaselessVoid>(player, CVSound);
             }
             else if (player.ZoneUnderworldHeight)
             {
-                SoundEngine.PlaySound(SignutSound, player.Center);
-                if (Main.netMode != NetmodeID.MultiplayerClient)
-                    NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Signus>());
-                else
-                    NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Signus>());
+                CalamityUtils.SpawnBossUsingItem<Signus>(player, SignutSound);
             }
             else if (player.ZoneSkyHeight)
             {
-                SoundEngine.PlaySound(StormSound, player.Center);
-                if (Main.netMode != NetmodeID.MultiplayerClient)
-                    NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<StormWeaverHead>());
-                else
-                    NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<StormWeaverHead>());
+                CalamityUtils.SpawnBossUsingItem<StormWeaverHead>(player, StormSound);
             }
 
             return true;

--- a/Items/SummonItems/SandstormsCore.cs
+++ b/Items/SummonItems/SandstormsCore.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.GreatSandShark;
-using CalamityMod.World;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -41,12 +39,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<GreatSandShark>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<GreatSandShark>());
-
+            CalamityUtils.SpawnBossUsingItem<GreatSandShark>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/Seafood.cs
+++ b/Items/SummonItems/Seafood.cs
@@ -3,7 +3,6 @@ using CalamityMod.Events;
 using CalamityMod.Items.Placeables;
 using CalamityMod.NPCs.AquaticScourge;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -41,12 +40,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<AquaticScourgeHead>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<AquaticScourgeHead>());
-
+            CalamityUtils.SpawnBossUsingItem<AquaticScourgeHead>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/Teratoma.cs
+++ b/Items/SummonItems/Teratoma.cs
@@ -2,7 +2,6 @@
 using CalamityMod.Items.Materials;
 using CalamityMod.NPCs.HiveMind;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -39,12 +38,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(SoundID.Roar, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<HiveMind>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<HiveMind>());
-
+            CalamityUtils.SpawnBossUsingItem<HiveMind>(player, SoundID.Roar);
             return true;
         }
 

--- a/Items/SummonItems/YharonEgg.cs
+++ b/Items/SummonItems/YharonEgg.cs
@@ -41,12 +41,7 @@ namespace CalamityMod.Items.SummonItems
 
         public override bool? UseItem(Player player)
         {
-            SoundEngine.PlaySound(Yharon.FireSound, player.Center);
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-                NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Yharon>());
-            else
-                NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Yharon>());
-
+            CalamityUtils.SpawnBossUsingItem<Yharon>(player, Yharon.FireSound);
             return true;
         }
 


### PR DESCRIPTION
Resolved Issue:
- Every boss summon items:
  - Removed `Non-Owner-Client` -> `Server` Netpath to reduce network usage
  - Added Util method for spawning boss: `CalamityUtils.SpawnBossUsingItem`, `CalamityUtils.SpawnBossOnPosUsingItem`
- `DeathWhistle`, `ProfandedCore`, `DecapoditaSprout`, `AstralChunk`:
  - now always spawn boss in intended position while in MP
- `OldPowerCell`:
  - now always can spawn Golem
  - Lihzahrd Temple check condition has replaced to `player.ZoneLihzhardTemple` instead of checking surrounding blocks
- `EidolonTablet`:
  - now properly spawn Cultist on MP
  - Lunar Event condition check now works in MP