### PR TITLE
Fix: Particle related NullReferenceException on Server

### DIFF
--- a/Particles/GeneralParticleHandler.cs
+++ b/Particles/GeneralParticleHandler.cs
@@ -70,6 +70,7 @@ namespace CalamityMod.Particles
             particleTypes = null;
             particleTextures = null;
             particleInstances = null;
+
             batchedAlphaBlendParticles = null;
             batchedNonPremultipliedParticles = null;
             batchedAdditiveBlendParticles = null;
@@ -95,6 +96,9 @@ namespace CalamityMod.Particles
 
         public static void Update()
         {
+            if (Main.dedServ)
+                return;
+
             foreach (Particle particle in particles)
             {
                 if (particle == null)
@@ -110,11 +114,17 @@ namespace CalamityMod.Particles
 
         public static void RemoveParticle(Particle particle)
         {
+            if (Main.dedServ)
+                return;
+
             particlesToKill.Add(particle);
         }
 
         public static void DrawAllParticles(SpriteBatch sb)
         {
+            if (Main.dedServ)
+                return;
+
             if (particles.Count == 0)
                 return;
 
@@ -221,7 +231,13 @@ namespace CalamityMod.Particles
         /// <summary>
         /// Gives you the texture of the particle type. Useful for custom drawing
         /// </summary>
-        public static Texture2D GetTexture(int type) => particleTextures[type];
+        public static Texture2D GetTexture(int type)
+        {
+            if (Main.dedServ)
+                return null;
+
+            return particleTextures[type];
+        }
 
 #pragma warning disable CS0414
         private static string noteToEveryone = "This particle system was inspired by spirit mod's own particle system, with permission granted by Yuyutsu. Love you spirit mod! -Iban";


### PR DESCRIPTION
Fixed NRE on Particle related codes caused by GeneralParticleHandler null list (server-side)

# Actual Exception Message:
```
[03:31:19.883] [Main Thread/WARN] [tML]: Silently Caught Exception: 
System.NullReferenceException: Object reference not set to an instance of an object.
   at CalamityMod.Projectiles.Melee.SwordsmithsPride.OnKill(Int32 timeLeft) in CalamityMod\Projectiles\Melee\TrueBiomeBlade_SwordsmithsPride.cs:line 288
   at Terraria.ModLoader.ProjectileLoader.OnKill(Projectile projectile, Int32 timeLeft) in tModLoader\Terraria\ModLoader\ProjectileLoader.cs:line 384
   at Terraria.Projectile.Kill() in tModLoader\Terraria\Projectile.cs:line 57364
```

# Cause and Fix
```cs
public override void OnKill(int timeLeft)
{
    if (smear != null)
        smear.Kill();
}

->

public void Kill() => GeneralParticleHandler.RemoveParticle(this);

->

public static void RemoveParticle(Particle particle)
{
    //NRE on here!
    //particlesToKill is null on dedServer
    //so PR adds Main.dedServ check on some GeneralParticleHandler methods
    particlesToKill.Add(particle); 
}
```