### PR TITLE
Fix: Liquid Desync caused by Water-spawning walls

### DIFF
--- a/Walls/AbyssGravelWall.cs
+++ b/Walls/AbyssGravelWall.cs
@@ -20,7 +20,7 @@ namespace CalamityMod.Walls
                 Main.tile[i, j].Get<LiquidData>().LiquidType = LiquidID.Water;
                 Main.tile[i, j].LiquidAmount = byte.MaxValue;
                 WorldGen.SquareTileFrame(i, j);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
+                if (Main.netMode == NetmodeID.Server)
                     NetMessage.sendWater(i, j);
             }
         }

--- a/Walls/EutrophicSandWall.cs
+++ b/Walls/EutrophicSandWall.cs
@@ -20,7 +20,7 @@ namespace CalamityMod.Walls
                 Main.tile[i, j].Get<LiquidData>().LiquidType = LiquidID.Water;
                 Main.tile[i, j].LiquidAmount = byte.MaxValue;
                 WorldGen.SquareTileFrame(i, j);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
+                if (Main.netMode == NetmodeID.Server)
                     NetMessage.sendWater(i, j);
             }
         }

--- a/Walls/PyreMantleWall.cs
+++ b/Walls/PyreMantleWall.cs
@@ -20,7 +20,7 @@ namespace CalamityMod.Walls
                 Main.tile[i, j].Get<LiquidData>().LiquidType = LiquidID.Water;
                 Main.tile[i, j].LiquidAmount = byte.MaxValue;
                 WorldGen.SquareTileFrame(i, j);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
+                if (Main.netMode == NetmodeID.Server)
                     NetMessage.sendWater(i, j);
             }
         }

--- a/Walls/VoidstoneWallUnsafe.cs
+++ b/Walls/VoidstoneWallUnsafe.cs
@@ -30,7 +30,7 @@ namespace CalamityMod.Walls
                 Main.tile[i, j].Get<LiquidData>().LiquidType = LiquidID.Water;
                 Main.tile[i, j].LiquidAmount = byte.MaxValue;
                 WorldGen.SquareTileFrame(i, j);
-                if (Main.netMode == NetmodeID.MultiplayerClient)
+                if (Main.netMode == NetmodeID.Server)
                     NetMessage.sendWater(i, j);
             }
         }


### PR DESCRIPTION
# Cause and Fix: 
```cs
// Random Update runs on SingleplayerClient OR Server
public override void RandomUpdate(int i, int j)
{
    if (Main.tile[i, j].LiquidAmount == 0 && j < Main.maxTilesY - 205)
    {
        Main.tile[i, j].Get<LiquidData>().LiquidType = LiquidID.Water;
        Main.tile[i, j].LiquidAmount = byte.MaxValue;
        WorldGen.SquareTileFrame(i, j);
        //This will never be called!
        //Therefore it will cause temporal (or pernament?) Liquid amount desync on MP
        //PR fix this to be NetmodeID.Server
        if (Main.netMode == NetmodeID.MultiplayerClient)
            NetMessage.sendWater(i, j);
    }
}
```