### PR TITLE
Fixed: Critical Networking Issue while equipping Shield/Barrier Item

### DIFF
--- a/Utilities/DrawingUtils.cs
+++ b/Utilities/DrawingUtils.cs
@@ -335,7 +335,7 @@ namespace CalamityMod
         }
 
         // Cached for efficiency purposes.
-        internal static readonly FieldInfo BeginEndPairField = typeof(SpriteBatch).GetField("inBeginEndPair", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static readonly FieldInfo BeginCalled = typeof(SpriteBatch).GetField("beginCalled", BindingFlags.NonPublic | BindingFlags.Instance);
 
         /// <summary>
         /// Determines if a <see cref="SpriteBatch"/> is in a lock due to a <see cref="SpriteBatch.Begin"/> call.
@@ -343,7 +343,39 @@ namespace CalamityMod
         /// <param name="spriteBatch">The sprite batch to check.</param>
         public static bool HasBeginBeenCalled(this SpriteBatch spriteBatch)
         {
-            return (bool)BeginEndPairField.GetValue(spriteBatch);
+            return (bool)BeginCalled.GetValue(spriteBatch);
+        }
+
+        public static bool TryBegin(this SpriteBatch spriteBatch, SpriteSortMode sortMode,
+            BlendState blendState,
+            SamplerState samplerState,
+            DepthStencilState depthStencilState,
+            RasterizerState rasterizerState,
+            Effect effect,
+            Matrix transformMatrix)
+        {
+            if (spriteBatch.HasBeginBeenCalled())
+            {
+                return false;
+            }
+            else
+            {
+                spriteBatch.Begin(sortMode, blendState, samplerState, depthStencilState, rasterizerState, effect, transformMatrix);
+                return true;
+            }
+        }
+
+        public static bool TryEnd(this SpriteBatch spriteBatch)
+        {
+            if (!spriteBatch.HasBeginBeenCalled())
+            {
+                return false;
+            }
+            else
+            {
+                spriteBatch.End();
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixed Issue:
- Barrier Type Item like `RoverDrive`, `TheSponge`, `LunicCorpsHelmet`  and Shield Type Item like `ShieldOfCthulhu`, `AsgardsValor`, `AsgardianAegis` and more
  - Now no longer make every network stream stuck. ClimateChange items like Cosmolight will now works without any issue

# Cause by:
Minor null reference exception on `UpdateItemDye->FindDyesDetour` at Server-side cause the issue it seems
As this method is called by Main game loop Eventually, it seems corrupted detour (caused by throwing exception on hook) caused network loop to be stuck in result
