### PR TITLE
Fixed: "Head Only WormBoss" bug in Multiplayer

### DIFF
--- a/CalamityNetcode.cs
+++ b/CalamityNetcode.cs
@@ -198,7 +198,7 @@ namespace CalamityMod
                         Vector2 position = reader.ReadVector2();
                         float rotation = (float)reader.ReadHalf(); //rotation unit is radian (-π/2 ≤ rotation ≤ π/2) so Half precision should works
 
-                        if (npcIndex >= 200)
+                        if (npcIndex >= Main.maxNPCs)
                             break;
 
                         npc = Main.npc[npcIndex];

--- a/CalamityNetcode.cs
+++ b/CalamityNetcode.cs
@@ -193,6 +193,29 @@ namespace CalamityMod
                         }
                         break;
 
+                    case CalamityModMessageType.SyncNPCPosAndRotOnly:
+                        npcIndex = reader.ReadByte();
+                        Vector2 position = reader.ReadVector2();
+                        float rotation = (float)reader.ReadHalf(); //rotation unit is radian (-π/2 ≤ rotation ≤ π/2) so Half precision should works
+
+                        if (npcIndex >= 200)
+                            break;
+
+                        npc = Main.npc[npcIndex];
+                        npc.position = position;
+                        npc.rotation = rotation;
+
+                        if (Main.dedServ)
+                        {
+                            ModPacket packet = CalamityMod.Instance.GetPacket();
+                            packet.Write((byte)CalamityModMessageType.SyncNPCPosAndRotOnly);
+                            packet.Write((byte)npcIndex);
+                            packet.WriteVector2(position);
+                            packet.Write((Half)rotation);
+                            packet.Send(ignoreClient: whoAmI);
+                        }
+                        break;
+
                     //
                     // Tile Entities
                     //
@@ -441,6 +464,7 @@ namespace CalamityMod
         // General things for entities
         SpawnNPCOnPlayer,
         SyncNPCMotionDataToServer,
+        SyncNPCPosAndRotOnly,
 
         // Tile Entities
         PowerCellFactory,

--- a/NPCs/CalamityNetImportantNPC.cs
+++ b/NPCs/CalamityNetImportantNPC.cs
@@ -24,16 +24,19 @@ using CalamityMod.NPCs.ProfanedGuardians;
 using CalamityMod.NPCs.Providence;
 using CalamityMod.NPCs.StormWeaver;
 using CalamityMod.NPCs.SupremeCalamitas;
+using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.Chat;
 using Terraria.DataStructures;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs
 {
     public sealed class CalamityNetImportantNPC : GlobalNPC
     {
-        private static HashSet<int> typesToUpdate;
+        private static Dictionary<int, int> typesToUpdate;
 
         public override void Load()
         {
@@ -49,29 +52,29 @@ namespace CalamityMod.NPCs
         public override void SetStaticDefaults()
         {
             #region Pre Hardmode
-            MarkNPCToNetImportant<DesertScourgeHead>();
-            MarkNPCToNetImportant<DesertScourgeBody>();
-            MarkNPCToNetImportant<DesertScourgeTail>();
+            MarkNPCToNetImportant<DesertScourgeHead>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<DesertScourgeBody>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<DesertScourgeTail>(netUpdateTickOffset: 1);
 
-            MarkNPCToNetImportant<DesertNuisanceHead>();
-            MarkNPCToNetImportant<DesertNuisanceBody>();
-            MarkNPCToNetImportant<DesertNuisanceTail>();
+            MarkNPCToNetImportant<DesertNuisanceHead>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<DesertNuisanceBody>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<DesertNuisanceTail>(netUpdateTickOffset: 2);
 
-            MarkNPCToNetImportant<DesertNuisanceHeadYoung>();
-            MarkNPCToNetImportant<DesertNuisanceBodyYoung>();
-            MarkNPCToNetImportant<DesertNuisanceTailYoung>();
+            MarkNPCToNetImportant<DesertNuisanceHeadYoung>(netUpdateTickOffset: 3);
+            MarkNPCToNetImportant<DesertNuisanceBodyYoung>(netUpdateTickOffset: 3);
+            MarkNPCToNetImportant<DesertNuisanceTailYoung>(netUpdateTickOffset: 3);
 
-            MarkNPCToNetImportant<PerforatorHeadSmall>();
-            MarkNPCToNetImportant<PerforatorBodySmall>();
-            MarkNPCToNetImportant<PerforatorTailSmall>();
+            MarkNPCToNetImportant<PerforatorHeadSmall>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<PerforatorBodySmall>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<PerforatorTailSmall>(netUpdateTickOffset: 1);
 
-            MarkNPCToNetImportant<PerforatorHeadMedium>();
-            MarkNPCToNetImportant<PerforatorBodyMedium>();
-            MarkNPCToNetImportant<PerforatorTailMedium>();
+            MarkNPCToNetImportant<PerforatorHeadMedium>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<PerforatorBodyMedium>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<PerforatorTailMedium>(netUpdateTickOffset: 2);
 
-            MarkNPCToNetImportant<PerforatorHeadLarge>();
-            MarkNPCToNetImportant<PerforatorBodyLarge>();
-            MarkNPCToNetImportant<PerforatorTailLarge>();
+            MarkNPCToNetImportant<PerforatorHeadLarge>(netUpdateTickOffset: 3);
+            MarkNPCToNetImportant<PerforatorBodyLarge>(netUpdateTickOffset: 3);
+            MarkNPCToNetImportant<PerforatorTailLarge>(netUpdateTickOffset: 3);
             #endregion Pre Hardmode
 
 
@@ -97,13 +100,13 @@ namespace CalamityMod.NPCs
 
 
             #region Post ML
-            MarkNPCToNetImportant<CosmicGuardianHead>();
-            MarkNPCToNetImportant<CosmicGuardianBody>();
-            MarkNPCToNetImportant<CosmicGuardianTail>();
+            MarkNPCToNetImportant<CosmicGuardianHead>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<CosmicGuardianBody>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<CosmicGuardianTail>(netUpdateTickOffset: 1);
 
-            MarkNPCToNetImportant<DevourerofGodsHead>();
-            MarkNPCToNetImportant<DevourerofGodsBody>();
-            MarkNPCToNetImportant<DevourerofGodsTail>();
+            MarkNPCToNetImportant<DevourerofGodsHead>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<DevourerofGodsBody>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<DevourerofGodsTail>(netUpdateTickOffset: 2);
 
             MarkNPCToNetImportant<StormWeaverHead>();
             MarkNPCToNetImportant<StormWeaverBody>();
@@ -133,10 +136,10 @@ namespace CalamityMod.NPCs
             MarkNPCToNetImportant<BobbitWormHead>();
             MarkNPCToNetImportant<BobbitWormSegment>();
 
-            MarkNPCToNetImportant<EidolonWyrmHead>();
-            MarkNPCToNetImportant<EidolonWyrmBody>();
-            MarkNPCToNetImportant<EidolonWyrmBodyAlt>();
-            MarkNPCToNetImportant<EidolonWyrmTail>();
+            MarkNPCToNetImportant<EidolonWyrmHead>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<EidolonWyrmBody>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<EidolonWyrmBodyAlt>(netUpdateTickOffset: 1);
+            MarkNPCToNetImportant<EidolonWyrmTail>(netUpdateTickOffset: 1);
 
             MarkNPCToNetImportant<GulperEelHead>();
             MarkNPCToNetImportant<GulperEelBody>();
@@ -147,10 +150,10 @@ namespace CalamityMod.NPCs
             MarkNPCToNetImportant<OarfishBody>();
             MarkNPCToNetImportant<OarfishTail>();
 
-            MarkNPCToNetImportant<PrimordialWyrmHead>();
-            MarkNPCToNetImportant<PrimordialWyrmBody>();
-            MarkNPCToNetImportant<PrimordialWyrmBodyAlt>();
-            MarkNPCToNetImportant<PrimordialWyrmTail>();
+            MarkNPCToNetImportant<PrimordialWyrmHead>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<PrimordialWyrmBody>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<PrimordialWyrmBodyAlt>(netUpdateTickOffset: 2);
+            MarkNPCToNetImportant<PrimordialWyrmTail>(netUpdateTickOffset: 2);
             #endregion Abyss
         }
 
@@ -164,33 +167,29 @@ namespace CalamityMod.NPCs
             if (!npc.active)
                 return;
 
-            if (Main.GameUpdateCount % 30 != 0)
+            if (!typesToUpdate.TryGetValue(npc.type, out var netUpdateTickOffset))
                 return;
 
-            if (!typesToUpdate.Contains(npc.type))
+            if ((Main.GameUpdateCount + netUpdateTickOffset) % 45 != 0)
                 return;
 
             foreach (var player in Main.ActivePlayers)
             {
-                // Exclude server client from distance check
-                if (player.whoAmI == Main.myPlayer)
-                    continue;
-
                 // distance between 1000~1500 update with 8 tick period
                 // and distance over 1500 will never update
-                // So we forcely update NPC distanced over 1500 with 30 tick period
-                float distance = CalamityUtils.ManhattanDistance(player.Center, npc.Center);
+                // So we forcely update NPC distanced over 1500 with 45 tick period
+                float distance = CalamityUtils.ManhattanDistance(player.position, npc.position);
                 if (distance <= 1499.0f)
                     continue;
 
-                NetMessage.SendData(MessageID.SyncNPC, player.whoAmI, -1, null, npc.whoAmI);
+                npc.SyncNPCPosAndRotOnly(); //Light-weight version to sync it's position
             }
         }
 
-        private void MarkNPCToNetImportant<NPCType>() where NPCType : ModNPC
+        private void MarkNPCToNetImportant<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
         {
             int type = ModContent.NPCType<NPCType>();
-            typesToUpdate.Add(type);
+            typesToUpdate[type] = netUpdateTickOffset;
         }
     }
 }

--- a/NPCs/CalamityNetImportantNPC.cs
+++ b/NPCs/CalamityNetImportantNPC.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CalamityMod.NPCs.Abyss;
+using CalamityMod.NPCs.AcidRain;
+using CalamityMod.NPCs.AquaticScourge;
+using CalamityMod.NPCs.AstrumDeus;
+using CalamityMod.NPCs.CalClone;
+using CalamityMod.NPCs.Cryogen;
+using CalamityMod.NPCs.DesertScourge;
+using CalamityMod.NPCs.DevourerofGods;
+using CalamityMod.NPCs.ExoMechs;
+using CalamityMod.NPCs.ExoMechs.Apollo;
+using CalamityMod.NPCs.ExoMechs.Ares;
+using CalamityMod.NPCs.ExoMechs.Artemis;
+using CalamityMod.NPCs.ExoMechs.Thanatos;
+using CalamityMod.NPCs.Leviathan;
+using CalamityMod.NPCs.NormalNPCs;
+using CalamityMod.NPCs.Perforator;
+using CalamityMod.NPCs.PrimordialWyrm;
+using CalamityMod.NPCs.ProfanedGuardians;
+using CalamityMod.NPCs.Providence;
+using CalamityMod.NPCs.StormWeaver;
+using CalamityMod.NPCs.SupremeCalamitas;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace CalamityMod.NPCs
+{
+    public sealed class CalamityNetImportantNPC : GlobalNPC
+    {
+        private static HashSet<int> typesToUpdate;
+
+        public override void Load()
+        {
+            typesToUpdate = new();
+        }
+
+        public override void Unload()
+        {
+            typesToUpdate?.Clear();
+            typesToUpdate = null;
+        }
+
+        public override void SetStaticDefaults()
+        {
+            #region Pre Hardmode
+            MarkNPCToNetImportant<DesertScourgeHead>();
+            MarkNPCToNetImportant<DesertScourgeBody>();
+            MarkNPCToNetImportant<DesertScourgeTail>();
+
+            MarkNPCToNetImportant<DesertNuisanceHead>();
+            MarkNPCToNetImportant<DesertNuisanceBody>();
+            MarkNPCToNetImportant<DesertNuisanceTail>();
+
+            MarkNPCToNetImportant<DesertNuisanceHeadYoung>();
+            MarkNPCToNetImportant<DesertNuisanceBodyYoung>();
+            MarkNPCToNetImportant<DesertNuisanceTailYoung>();
+
+            MarkNPCToNetImportant<PerforatorHeadSmall>();
+            MarkNPCToNetImportant<PerforatorBodySmall>();
+            MarkNPCToNetImportant<PerforatorTailSmall>();
+
+            MarkNPCToNetImportant<PerforatorHeadMedium>();
+            MarkNPCToNetImportant<PerforatorBodyMedium>();
+            MarkNPCToNetImportant<PerforatorTailMedium>();
+
+            MarkNPCToNetImportant<PerforatorHeadLarge>();
+            MarkNPCToNetImportant<PerforatorBodyLarge>();
+            MarkNPCToNetImportant<PerforatorTailLarge>();
+            #endregion Pre Hardmode
+
+
+
+            #region Hardmode
+            MarkNPCToNetImportant<AquaticScourgeHead>();
+            MarkNPCToNetImportant<AquaticScourgeBody>();
+            MarkNPCToNetImportant<AquaticScourgeBodyAlt>();
+            MarkNPCToNetImportant<AquaticScourgeTail>();
+
+            MarkNPCToNetImportant<ArmoredDiggerHead>();
+            MarkNPCToNetImportant<ArmoredDiggerBody>();
+            MarkNPCToNetImportant<ArmoredDiggerTail>();
+
+            MarkNPCToNetImportant<AstrumDeusHead>();
+            MarkNPCToNetImportant<AstrumDeusBody>();
+            MarkNPCToNetImportant<AstrumDeusTail>();
+
+            MarkNPCToNetImportant<Cryogen.Cryogen>();
+            MarkNPCToNetImportant<CryogenShield>();
+            #endregion Hardmode
+
+
+
+            #region Post ML
+            MarkNPCToNetImportant<CosmicGuardianHead>();
+            MarkNPCToNetImportant<CosmicGuardianBody>();
+            MarkNPCToNetImportant<CosmicGuardianTail>();
+
+            MarkNPCToNetImportant<DevourerofGodsHead>();
+            MarkNPCToNetImportant<DevourerofGodsBody>();
+            MarkNPCToNetImportant<DevourerofGodsTail>();
+
+            MarkNPCToNetImportant<StormWeaverHead>();
+            MarkNPCToNetImportant<StormWeaverBody>();
+            MarkNPCToNetImportant<StormWeaverTail>();
+            #endregion Post ML
+
+
+            #region Calamitas Boss
+            MarkNPCToNetImportant<SepulcherHead>();
+            MarkNPCToNetImportant<SepulcherBody>();
+            MarkNPCToNetImportant<SepulcherTail>();
+            #endregion
+
+
+            #region Draedon Boss
+            MarkNPCToNetImportant<Draedon>();
+
+            MarkNPCToNetImportant<ThanatosHead>();
+            MarkNPCToNetImportant<ThanatosBody1>();
+            MarkNPCToNetImportant<ThanatosBody2>();
+            MarkNPCToNetImportant<ThanatosTail>();
+            #endregion Draedon Boss
+
+
+
+            #region Abyss
+            MarkNPCToNetImportant<BobbitWormHead>();
+            MarkNPCToNetImportant<BobbitWormSegment>();
+
+            MarkNPCToNetImportant<EidolonWyrmHead>();
+            MarkNPCToNetImportant<EidolonWyrmBody>();
+            MarkNPCToNetImportant<EidolonWyrmBodyAlt>();
+            MarkNPCToNetImportant<EidolonWyrmTail>();
+
+            MarkNPCToNetImportant<GulperEelHead>();
+            MarkNPCToNetImportant<GulperEelBody>();
+            MarkNPCToNetImportant<GulperEelBodyAlt>();
+            MarkNPCToNetImportant<GulperEelTail>();
+
+            MarkNPCToNetImportant<OarfishHead>();
+            MarkNPCToNetImportant<OarfishBody>();
+            MarkNPCToNetImportant<OarfishTail>();
+
+            MarkNPCToNetImportant<PrimordialWyrmHead>();
+            MarkNPCToNetImportant<PrimordialWyrmBody>();
+            MarkNPCToNetImportant<PrimordialWyrmBodyAlt>();
+            MarkNPCToNetImportant<PrimordialWyrmTail>();
+            #endregion Abyss
+        }
+
+        public override void PostAI(NPC npc)
+        {
+            // Only Server should update this!
+            if (!Main.dedServ)
+                return;
+
+            // Obviously deactived npc is not on our interest (not sure if this is case though)
+            if (!npc.active)
+                return;
+
+            if (Main.GameUpdateCount % 30 != 0)
+                return;
+
+            if (!typesToUpdate.Contains(npc.type))
+                return;
+
+            foreach (var player in Main.ActivePlayers)
+            {
+                // Exclude server client from distance check
+                if (player.whoAmI == Main.myPlayer)
+                    continue;
+
+                // distance between 1000~1500 update with 8 tick period
+                // and distance over 1500 will never update
+                // So we forcely update NPC distanced over 1500 with 30 tick period
+                float distance = CalamityUtils.ManhattanDistance(player.Center, npc.Center);
+                if (distance <= 1499.0f)
+                    continue;
+
+                NetMessage.SendData(MessageID.SyncNPC, player.whoAmI, -1, null, npc.whoAmI);
+            }
+        }
+
+        private void MarkNPCToNetImportant<NPCType>() where NPCType : ModNPC
+        {
+            int type = ModContent.NPCType<NPCType>();
+            typesToUpdate.Add(type);
+        }
+    }
+}

--- a/NPCs/CalamityNetImportantNPC.cs
+++ b/NPCs/CalamityNetImportantNPC.cs
@@ -51,6 +51,18 @@ namespace CalamityMod.NPCs
 
         public override void SetStaticDefaults()
         {
+            #region Vanilla Enemies
+            MarkNPCToNetImportant(NPCID.EaterofWorldsHead);
+            MarkNPCToNetImportant(NPCID.EaterofWorldsBody);
+            MarkNPCToNetImportant(NPCID.EaterofWorldsTail);
+
+            MarkNPCToNetImportant(NPCID.TheDestroyer);
+            MarkNPCToNetImportant(NPCID.TheDestroyerBody);
+            MarkNPCToNetImportant(NPCID.TheDestroyerTail);
+            #endregion Vanilla Enemies
+
+
+
             #region Pre Hardmode
             MarkNPCToNetImportant<DesertScourgeHead>(netUpdateTickOffset: 1);
             MarkNPCToNetImportant<DesertScourgeBody>(netUpdateTickOffset: 1);
@@ -188,8 +200,12 @@ namespace CalamityMod.NPCs
 
         private void MarkNPCToNetImportant<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
         {
-            int type = ModContent.NPCType<NPCType>();
-            typesToUpdate[type] = netUpdateTickOffset;
+            MarkNPCToNetImportant(ModContent.NPCType<NPCType>(), netUpdateTickOffset);
+        }
+
+        private void MarkNPCToNetImportant(int npcType, int netUpdateTickOffset = 0)
+        {
+            typesToUpdate[npcType] = netUpdateTickOffset;
         }
     }
 }

--- a/Utilities/NPCUtils.cs
+++ b/Utilities/NPCUtils.cs
@@ -310,6 +310,16 @@ namespace CalamityMod
             netMessage.Send();
         }
 
+        public static void SyncNPCPosAndRotOnly(this NPC npc)
+        {
+            ModPacket packet = CalamityMod.Instance.GetPacket();
+            packet.Write((byte)CalamityModMessageType.SyncNPCPosAndRotOnly);
+            packet.Write((byte)npc.whoAmI);
+            packet.WriteVector2(npc.position);
+            packet.Write((Half)npc.rotation);
+            packet.Send();
+        }
+
         /// <summary>
         /// Syncs <see cref="CalamityGlobalNPC.destroyerLaserColor"/>. This exists to sync the Destroyer's lasers so that the telegraphs and segment colors display properly.
         /// </summary>


### PR DESCRIPTION
# Cause:
`NPC.UpdateNetworkCode` check distance between NPC and Player and Dynamically change NetSync period

However if distance between NPC and Player is over 1500, NetSync stops for that NPC.

This is normally not a big issue for most of NPC, but for Worm bosses body part that doesn't despawn by distance. It simply stops sync until manually set `netUpdate` to true

So this PR Introduce `GlobalNPC` type `CalamityNetImportantNPC`, which force update the "too far away" NPCs every 30 frames if it's marked as `NetImportant` in `CalamityNetImportantNPC.SetStaticDefaults`

# Rooms for Improvement:
For now, it's hardcoded as this is Public Pull Request and I didn't wanted to mark multiple "potentially edited on private repo" NPCs
But this can be improved by using Reflection to Dynamically look for target NPCs