### PR TITLE
CalamityNetImportantNPC now uses Attribute

### DIFF
--- a/NPCs/Abyss/BobbitWormHead.cs
+++ b/NPCs/Abyss/BobbitWormHead.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform]
     public class BobbitWormHead : ModNPC
     {
         public override void SetStaticDefaults()

--- a/NPCs/Abyss/BobbitWormHead.cs
+++ b/NPCs/Abyss/BobbitWormHead.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class BobbitWormHead : ModNPC
     {
         public override void SetStaticDefaults()

--- a/NPCs/Abyss/BobbitWormSegment.cs
+++ b/NPCs/Abyss/BobbitWormSegment.cs
@@ -7,6 +7,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(BobbitWormHead))]
     public class BobbitWormSegment : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.BobbitWormHead.DisplayName");

--- a/NPCs/Abyss/BobbitWormSegment.cs
+++ b/NPCs/Abyss/BobbitWormSegment.cs
@@ -7,7 +7,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(BobbitWormHead))]
+    [LongDistanceNetSync(SyncWith = typeof(BobbitWormHead))]
     public class BobbitWormSegment : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.BobbitWormHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmBody.cs
+++ b/NPCs/Abyss/EidolonWyrmBody.cs
@@ -9,6 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmBody.cs
+++ b/NPCs/Abyss/EidolonWyrmBody.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmBodyAlt.cs
+++ b/NPCs/Abyss/EidolonWyrmBodyAlt.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmBodyAlt.cs
+++ b/NPCs/Abyss/EidolonWyrmBodyAlt.cs
@@ -9,6 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmHead.cs
+++ b/NPCs/Abyss/EidolonWyrmHead.cs
@@ -26,7 +26,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class EidolonWyrmHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/EidolonWyrmHead.cs
+++ b/NPCs/Abyss/EidolonWyrmHead.cs
@@ -26,6 +26,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform]
     public class EidolonWyrmHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/EidolonWyrmTail.cs
+++ b/NPCs/Abyss/EidolonWyrmTail.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/EidolonWyrmTail.cs
+++ b/NPCs/Abyss/EidolonWyrmTail.cs
@@ -9,6 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(EidolonWyrmHead))]
     public class EidolonWyrmTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.EidolonWyrmHead.DisplayName");

--- a/NPCs/Abyss/GulperEelBody.cs
+++ b/NPCs/Abyss/GulperEelBody.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
+    [LongDistanceNetSync(SyncWith = typeof(GulperEelHead))]
     public class GulperEelBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/GulperEelBody.cs
+++ b/NPCs/Abyss/GulperEelBody.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
     public class GulperEelBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/GulperEelBodyAlt.cs
+++ b/NPCs/Abyss/GulperEelBodyAlt.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
     public class GulperEelBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/GulperEelBodyAlt.cs
+++ b/NPCs/Abyss/GulperEelBodyAlt.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
+    [LongDistanceNetSync(SyncWith = typeof(GulperEelHead))]
     public class GulperEelBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/GulperEelHead.cs
+++ b/NPCs/Abyss/GulperEelHead.cs
@@ -16,7 +16,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class GulperEelHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/GulperEelHead.cs
+++ b/NPCs/Abyss/GulperEelHead.cs
@@ -16,6 +16,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform]
     public class GulperEelHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/GulperEelTail.cs
+++ b/NPCs/Abyss/GulperEelTail.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
+    [LongDistanceNetSync(SyncWith = typeof(GulperEelHead))]
     public class GulperEelTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/GulperEelTail.cs
+++ b/NPCs/Abyss/GulperEelTail.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(GulperEelHead))]
     public class GulperEelTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.GulperEelHead.DisplayName");

--- a/NPCs/Abyss/OarfishBody.cs
+++ b/NPCs/Abyss/OarfishBody.cs
@@ -7,7 +7,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(OarfishHead))]
+    [LongDistanceNetSync(SyncWith = typeof(OarfishHead))]
     public class OarfishBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.OarfishHead.DisplayName");

--- a/NPCs/Abyss/OarfishBody.cs
+++ b/NPCs/Abyss/OarfishBody.cs
@@ -7,6 +7,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(OarfishHead))]
     public class OarfishBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.OarfishHead.DisplayName");

--- a/NPCs/Abyss/OarfishHead.cs
+++ b/NPCs/Abyss/OarfishHead.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform]
     public class OarfishHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/OarfishHead.cs
+++ b/NPCs/Abyss/OarfishHead.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader.Utilities;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class OarfishHead : ModNPC
     {
         private Vector2 patrolSpot = Vector2.Zero;

--- a/NPCs/Abyss/OarfishTail.cs
+++ b/NPCs/Abyss/OarfishTail.cs
@@ -7,6 +7,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
+    [AlwaysSyncTransform(SyncWith = typeof(OarfishHead))]
     public class OarfishTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.OarfishHead.DisplayName");

--- a/NPCs/Abyss/OarfishTail.cs
+++ b/NPCs/Abyss/OarfishTail.cs
@@ -7,7 +7,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Abyss
 {
-    [AlwaysSyncTransform(SyncWith = typeof(OarfishHead))]
+    [LongDistanceNetSync(SyncWith = typeof(OarfishHead))]
     public class OarfishTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.OarfishHead.DisplayName");

--- a/NPCs/AlwaysSyncTransformAttribute.cs
+++ b/NPCs/AlwaysSyncTransformAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace CalamityMod.NPCs
+{
+    /// <summary>
+    /// This attribute allows ModNPC to always sync for their position and rotation data at least every 45 frames
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class AlwaysSyncTransformAttribute : Attribute
+    {
+        /// <summary>
+        /// Syncs this NPC to other NPC's sync frame
+        /// <para>If this is not present, We cannot properly sync full NPC bodyparts in same frame! (This is important for Worm-type NPCs)</para>
+        /// </summary>
+        public Type SyncWith { get; set; } = null;
+
+        public AlwaysSyncTransformAttribute()
+        {
+
+        }
+    }
+}

--- a/NPCs/AquaticScourge/AquaticScourgeBody.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeBody.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
+    [LongDistanceNetSync(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AquaticScourge/AquaticScourgeBody.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeBody.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AquaticScourge/AquaticScourgeBodyAlt.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeBodyAlt.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
+    [LongDistanceNetSync(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AquaticScourge/AquaticScourgeBodyAlt.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeBodyAlt.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeBodyAlt : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AquaticScourge/AquaticScourgeHead.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeHead.cs
@@ -33,6 +33,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.AquaticScourge
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class AquaticScourgeHead : ModNPC
     {
         public override void SetStaticDefaults()

--- a/NPCs/AquaticScourge/AquaticScourgeHead.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeHead.cs
@@ -33,7 +33,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.AquaticScourge
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class AquaticScourgeHead : ModNPC
     {
         public override void SetStaticDefaults()

--- a/NPCs/AquaticScourge/AquaticScourgeTail.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeTail.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AquaticScourge/AquaticScourgeTail.cs
+++ b/NPCs/AquaticScourge/AquaticScourgeTail.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AquaticScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(AquaticScourgeHead))]
+    [LongDistanceNetSync(SyncWith = typeof(AquaticScourgeHead))]
     public class AquaticScourgeTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AquaticScourgeHead.DisplayName");

--- a/NPCs/AstrumDeus/AstrumDeusBody.cs
+++ b/NPCs/AstrumDeus/AstrumDeusBody.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AstrumDeus
 {
-    [AlwaysSyncTransform(SyncWith = typeof(AstrumDeusHead))]
+    [LongDistanceNetSync(SyncWith = typeof(AstrumDeusHead))]
     public class AstrumDeusBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AstrumDeusHead.DisplayName");

--- a/NPCs/AstrumDeus/AstrumDeusBody.cs
+++ b/NPCs/AstrumDeus/AstrumDeusBody.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AstrumDeus
 {
+    [AlwaysSyncTransform(SyncWith = typeof(AstrumDeusHead))]
     public class AstrumDeusBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AstrumDeusHead.DisplayName");

--- a/NPCs/AstrumDeus/AstrumDeusHead.cs
+++ b/NPCs/AstrumDeus/AstrumDeusHead.cs
@@ -34,6 +34,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.AstrumDeus
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class AstrumDeusHead : ModNPC
     {
         public static readonly SoundStyle SpawnSound = new("CalamityMod/Sounds/Custom/AstrumDeus/AstrumDeusSpawn");

--- a/NPCs/AstrumDeus/AstrumDeusHead.cs
+++ b/NPCs/AstrumDeus/AstrumDeusHead.cs
@@ -34,7 +34,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.AstrumDeus
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class AstrumDeusHead : ModNPC
     {
         public static readonly SoundStyle SpawnSound = new("CalamityMod/Sounds/Custom/AstrumDeus/AstrumDeusSpawn");

--- a/NPCs/AstrumDeus/AstrumDeusTail.cs
+++ b/NPCs/AstrumDeus/AstrumDeusTail.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AstrumDeus
 {
-    [AlwaysSyncTransform(SyncWith = typeof(AstrumDeusHead))]
+    [LongDistanceNetSync(SyncWith = typeof(AstrumDeusHead))]
     public class AstrumDeusTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AstrumDeusHead.DisplayName");

--- a/NPCs/AstrumDeus/AstrumDeusTail.cs
+++ b/NPCs/AstrumDeus/AstrumDeusTail.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.AstrumDeus
 {
+    [AlwaysSyncTransform(SyncWith = typeof(AstrumDeusHead))]
     public class AstrumDeusTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.AstrumDeusHead.DisplayName");

--- a/NPCs/CalamityNetImportantNPC.cs
+++ b/NPCs/CalamityNetImportantNPC.cs
@@ -30,14 +30,14 @@ namespace CalamityMod.NPCs
             int uniqueNetOffsetID = 0;
 
             #region Vanilla Enemies
-            MarkNPCToNetImportant(NPCID.EaterofWorldsHead, uniqueNetOffsetID);
-            MarkNPCToNetImportant(NPCID.EaterofWorldsBody, uniqueNetOffsetID);
-            MarkNPCToNetImportant(NPCID.EaterofWorldsTail, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.EaterofWorldsHead, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.EaterofWorldsBody, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.EaterofWorldsTail, uniqueNetOffsetID);
             uniqueNetOffsetID++;
 
-            MarkNPCToNetImportant(NPCID.TheDestroyer, uniqueNetOffsetID);
-            MarkNPCToNetImportant(NPCID.TheDestroyerBody, uniqueNetOffsetID);
-            MarkNPCToNetImportant(NPCID.TheDestroyerTail, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.TheDestroyer, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.TheDestroyerBody, uniqueNetOffsetID);
+            MarkNPCToLongDistanceSync(NPCID.TheDestroyerTail, uniqueNetOffsetID);
             uniqueNetOffsetID++;
             #endregion Vanilla Enemies
 
@@ -51,9 +51,9 @@ namespace CalamityMod.NPCs
             {
                 try
                 {
-                    var syncAttribute = type.GetCustomAttribute<AlwaysSyncTransformAttribute>();
+                    var longDistSync = type.GetCustomAttribute<LongDistanceNetSyncAttribute>();
 
-                    if (syncAttribute == null)
+                    if (longDistSync == null)
                         continue;
 
                     var npcTypeActualMethod = npcTypeMethod.MakeGenericMethod(typeArguments: type);
@@ -61,7 +61,7 @@ namespace CalamityMod.NPCs
                     int npcType = (int)npcTypeActualMethod.Invoke(null, null);
                     int netOffset = uniqueNetOffsetID;
 
-                    Type typeToCheck = syncAttribute.SyncWith ?? type;
+                    Type typeToCheck = longDistSync.SyncWith ?? type;
                     if (netOffsetTable.TryGetValue(typeToCheck, out int savedUniqueID))
                     {
                         netOffset = savedUniqueID;
@@ -72,7 +72,7 @@ namespace CalamityMod.NPCs
                         uniqueNetOffsetID++;
                     }
 
-                    MarkNPCToNetImportant(npcType, netOffset);
+                    MarkNPCToLongDistanceSync(npcType, netOffset);
                 }
                 catch (Exception e)
                 {
@@ -112,12 +112,12 @@ namespace CalamityMod.NPCs
             }
         }
 
-        private static void MarkNPCToNetImportant<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
+        private static void MarkNPCToLongDistanceSync<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
         {
-            MarkNPCToNetImportant(ModContent.NPCType<NPCType>(), netUpdateTickOffset);
+            MarkNPCToLongDistanceSync(ModContent.NPCType<NPCType>(), netUpdateTickOffset);
         }
 
-        private static void MarkNPCToNetImportant(int npcType, int netUpdateTickOffset = 0)
+        private static void MarkNPCToLongDistanceSync(int npcType, int netUpdateTickOffset = 0)
         {
             typesToUpdate[npcType] = netUpdateTickOffset;
         }

--- a/NPCs/CalamityNetImportantNPC.cs
+++ b/NPCs/CalamityNetImportantNPC.cs
@@ -1,36 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CalamityMod.NPCs.Abyss;
-using CalamityMod.NPCs.AcidRain;
-using CalamityMod.NPCs.AquaticScourge;
-using CalamityMod.NPCs.AstrumDeus;
-using CalamityMod.NPCs.CalClone;
-using CalamityMod.NPCs.Cryogen;
-using CalamityMod.NPCs.DesertScourge;
-using CalamityMod.NPCs.DevourerofGods;
-using CalamityMod.NPCs.ExoMechs;
-using CalamityMod.NPCs.ExoMechs.Apollo;
-using CalamityMod.NPCs.ExoMechs.Ares;
-using CalamityMod.NPCs.ExoMechs.Artemis;
-using CalamityMod.NPCs.ExoMechs.Thanatos;
-using CalamityMod.NPCs.Leviathan;
-using CalamityMod.NPCs.NormalNPCs;
-using CalamityMod.NPCs.Perforator;
-using CalamityMod.NPCs.PrimordialWyrm;
-using CalamityMod.NPCs.ProfanedGuardians;
-using CalamityMod.NPCs.Providence;
-using CalamityMod.NPCs.StormWeaver;
-using CalamityMod.NPCs.SupremeCalamitas;
-using Microsoft.Xna.Framework;
+using System.Reflection;
 using Terraria;
-using Terraria.Chat;
-using Terraria.DataStructures;
 using Terraria.ID;
-using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 
 namespace CalamityMod.NPCs
 {
@@ -51,122 +27,60 @@ namespace CalamityMod.NPCs
 
         public override void SetStaticDefaults()
         {
-            #region Vanilla Enemies
-            MarkNPCToNetImportant(NPCID.EaterofWorldsHead);
-            MarkNPCToNetImportant(NPCID.EaterofWorldsBody);
-            MarkNPCToNetImportant(NPCID.EaterofWorldsTail);
+            int uniqueNetOffsetID = 0;
 
-            MarkNPCToNetImportant(NPCID.TheDestroyer);
-            MarkNPCToNetImportant(NPCID.TheDestroyerBody);
-            MarkNPCToNetImportant(NPCID.TheDestroyerTail);
+            #region Vanilla Enemies
+            MarkNPCToNetImportant(NPCID.EaterofWorldsHead, uniqueNetOffsetID);
+            MarkNPCToNetImportant(NPCID.EaterofWorldsBody, uniqueNetOffsetID);
+            MarkNPCToNetImportant(NPCID.EaterofWorldsTail, uniqueNetOffsetID);
+            uniqueNetOffsetID++;
+
+            MarkNPCToNetImportant(NPCID.TheDestroyer, uniqueNetOffsetID);
+            MarkNPCToNetImportant(NPCID.TheDestroyerBody, uniqueNetOffsetID);
+            MarkNPCToNetImportant(NPCID.TheDestroyerTail, uniqueNetOffsetID);
+            uniqueNetOffsetID++;
             #endregion Vanilla Enemies
 
+            var types = AssemblyManager.GetLoadableTypes(CalamityMod.Instance.Code)
+                .Where(type => !type.IsAbstract && type.IsSubclassOf(typeof(ModNPC)));
 
+            // Caching this for better performance
+            var npcTypeMethod = typeof(ModContent).GetMethod(nameof(ModContent.NPCType));
+            var netOffsetTable = new Dictionary<Type, int>();
+            foreach (var type in types)
+            {
+                try
+                {
+                    var syncAttribute = type.GetCustomAttribute<AlwaysSyncTransformAttribute>();
 
-            #region Pre Hardmode
-            MarkNPCToNetImportant<DesertScourgeHead>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<DesertScourgeBody>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<DesertScourgeTail>(netUpdateTickOffset: 1);
+                    if (syncAttribute == null)
+                        continue;
 
-            MarkNPCToNetImportant<DesertNuisanceHead>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<DesertNuisanceBody>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<DesertNuisanceTail>(netUpdateTickOffset: 2);
+                    var npcTypeActualMethod = npcTypeMethod.MakeGenericMethod(typeArguments: type);
 
-            MarkNPCToNetImportant<DesertNuisanceHeadYoung>(netUpdateTickOffset: 3);
-            MarkNPCToNetImportant<DesertNuisanceBodyYoung>(netUpdateTickOffset: 3);
-            MarkNPCToNetImportant<DesertNuisanceTailYoung>(netUpdateTickOffset: 3);
+                    int npcType = (int)npcTypeActualMethod.Invoke(null, null);
+                    int netOffset = uniqueNetOffsetID;
 
-            MarkNPCToNetImportant<PerforatorHeadSmall>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<PerforatorBodySmall>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<PerforatorTailSmall>(netUpdateTickOffset: 1);
+                    Type typeToCheck = syncAttribute.SyncWith ?? type;
+                    if (netOffsetTable.TryGetValue(typeToCheck, out int savedUniqueID))
+                    {
+                        netOffset = savedUniqueID;
+                    }
+                    else
+                    {
+                        netOffsetTable[typeToCheck] = netOffset;
+                        uniqueNetOffsetID++;
+                    }
 
-            MarkNPCToNetImportant<PerforatorHeadMedium>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<PerforatorBodyMedium>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<PerforatorTailMedium>(netUpdateTickOffset: 2);
+                    MarkNPCToNetImportant(npcType, netOffset);
+                }
+                catch (Exception e)
+                {
+                    CalamityMod.Instance.Logger.Error($"Exception thrown while evaluating type \"{type.Name}\": {e}");
+                }
+            }
 
-            MarkNPCToNetImportant<PerforatorHeadLarge>(netUpdateTickOffset: 3);
-            MarkNPCToNetImportant<PerforatorBodyLarge>(netUpdateTickOffset: 3);
-            MarkNPCToNetImportant<PerforatorTailLarge>(netUpdateTickOffset: 3);
-            #endregion Pre Hardmode
-
-
-
-            #region Hardmode
-            MarkNPCToNetImportant<AquaticScourgeHead>();
-            MarkNPCToNetImportant<AquaticScourgeBody>();
-            MarkNPCToNetImportant<AquaticScourgeBodyAlt>();
-            MarkNPCToNetImportant<AquaticScourgeTail>();
-
-            MarkNPCToNetImportant<ArmoredDiggerHead>();
-            MarkNPCToNetImportant<ArmoredDiggerBody>();
-            MarkNPCToNetImportant<ArmoredDiggerTail>();
-
-            MarkNPCToNetImportant<AstrumDeusHead>();
-            MarkNPCToNetImportant<AstrumDeusBody>();
-            MarkNPCToNetImportant<AstrumDeusTail>();
-
-            MarkNPCToNetImportant<Cryogen.Cryogen>();
-            MarkNPCToNetImportant<CryogenShield>();
-            #endregion Hardmode
-
-
-
-            #region Post ML
-            MarkNPCToNetImportant<CosmicGuardianHead>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<CosmicGuardianBody>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<CosmicGuardianTail>(netUpdateTickOffset: 1);
-
-            MarkNPCToNetImportant<DevourerofGodsHead>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<DevourerofGodsBody>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<DevourerofGodsTail>(netUpdateTickOffset: 2);
-
-            MarkNPCToNetImportant<StormWeaverHead>();
-            MarkNPCToNetImportant<StormWeaverBody>();
-            MarkNPCToNetImportant<StormWeaverTail>();
-            #endregion Post ML
-
-
-            #region Calamitas Boss
-            MarkNPCToNetImportant<SepulcherHead>();
-            MarkNPCToNetImportant<SepulcherBody>();
-            MarkNPCToNetImportant<SepulcherTail>();
-            #endregion
-
-
-            #region Draedon Boss
-            MarkNPCToNetImportant<Draedon>();
-
-            MarkNPCToNetImportant<ThanatosHead>();
-            MarkNPCToNetImportant<ThanatosBody1>();
-            MarkNPCToNetImportant<ThanatosBody2>();
-            MarkNPCToNetImportant<ThanatosTail>();
-            #endregion Draedon Boss
-
-
-
-            #region Abyss
-            MarkNPCToNetImportant<BobbitWormHead>();
-            MarkNPCToNetImportant<BobbitWormSegment>();
-
-            MarkNPCToNetImportant<EidolonWyrmHead>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<EidolonWyrmBody>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<EidolonWyrmBodyAlt>(netUpdateTickOffset: 1);
-            MarkNPCToNetImportant<EidolonWyrmTail>(netUpdateTickOffset: 1);
-
-            MarkNPCToNetImportant<GulperEelHead>();
-            MarkNPCToNetImportant<GulperEelBody>();
-            MarkNPCToNetImportant<GulperEelBodyAlt>();
-            MarkNPCToNetImportant<GulperEelTail>();
-
-            MarkNPCToNetImportant<OarfishHead>();
-            MarkNPCToNetImportant<OarfishBody>();
-            MarkNPCToNetImportant<OarfishTail>();
-
-            MarkNPCToNetImportant<PrimordialWyrmHead>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<PrimordialWyrmBody>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<PrimordialWyrmBodyAlt>(netUpdateTickOffset: 2);
-            MarkNPCToNetImportant<PrimordialWyrmTail>(netUpdateTickOffset: 2);
-            #endregion Abyss
+            netOffsetTable?.Clear();
         }
 
         public override void PostAI(NPC npc)
@@ -198,12 +112,12 @@ namespace CalamityMod.NPCs
             }
         }
 
-        private void MarkNPCToNetImportant<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
+        private static void MarkNPCToNetImportant<NPCType>(int netUpdateTickOffset = 0) where NPCType : ModNPC
         {
             MarkNPCToNetImportant(ModContent.NPCType<NPCType>(), netUpdateTickOffset);
         }
 
-        private void MarkNPCToNetImportant(int npcType, int netUpdateTickOffset = 0)
+        private static void MarkNPCToNetImportant(int npcType, int netUpdateTickOffset = 0)
         {
             typesToUpdate[npcType] = netUpdateTickOffset;
         }

--- a/NPCs/Cryogen/Cryogen.cs
+++ b/NPCs/Cryogen/Cryogen.cs
@@ -39,7 +39,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Cryogen
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform] // Cryogen follows you forever like Queen Bee in vanilla, So we need this to sync it's position on minimap
+    [LongDistanceNetSync] // Cryogen follows you forever like Queen Bee in vanilla, So we need this to sync it's position on minimap
     public class Cryogen : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/Cryogen/Cryogen.cs
+++ b/NPCs/Cryogen/Cryogen.cs
@@ -39,6 +39,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Cryogen
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform] // Cryogen follows you forever like Queen Bee in vanilla, So we need this to sync it's position on minimap
     public class Cryogen : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/Cryogen/CryogenShield.cs
+++ b/NPCs/Cryogen/CryogenShield.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Cryogen
 {
+    [AlwaysSyncTransform(SyncWith = typeof(Cryogen))]
     public class CryogenShield : ModNPC
     {
         public static readonly SoundStyle BreakSound = new("CalamityMod/Sounds/NPCKilled/CryogenShieldBreak");

--- a/NPCs/Cryogen/CryogenShield.cs
+++ b/NPCs/Cryogen/CryogenShield.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Cryogen
 {
-    [AlwaysSyncTransform(SyncWith = typeof(Cryogen))]
+    [LongDistanceNetSync(SyncWith = typeof(Cryogen))]
     public class CryogenShield : ModNPC
     {
         public static readonly SoundStyle BreakSound = new("CalamityMod/Sounds/NPCKilled/CryogenShieldBreak");

--- a/NPCs/DesertScourge/DesertNuisanceBody.cs
+++ b/NPCs/DesertScourge/DesertNuisanceBody.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHead))]
     public class DesertNuisanceBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHead.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceBody.cs
+++ b/NPCs/DesertScourge/DesertNuisanceBody.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertNuisanceHead))]
     public class DesertNuisanceBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHead.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceBodyYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceBodyYoung.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHeadYoung))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertNuisanceHeadYoung))]
     public class DesertNuisanceBodyYoung : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHeadYoung.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceBodyYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceBodyYoung.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHeadYoung))]
     public class DesertNuisanceBodyYoung : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHeadYoung.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceHead.cs
+++ b/NPCs/DesertScourge/DesertNuisanceHead.cs
@@ -12,7 +12,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class DesertNuisanceHead : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertNuisanceHead.cs
+++ b/NPCs/DesertScourge/DesertNuisanceHead.cs
@@ -12,6 +12,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class DesertNuisanceHead : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertNuisanceHeadYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceHeadYoung.cs
@@ -14,6 +14,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class DesertNuisanceHeadYoung : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertNuisanceHeadYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceHeadYoung.cs
@@ -14,7 +14,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class DesertNuisanceHeadYoung : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertNuisanceTail.cs
+++ b/NPCs/DesertScourge/DesertNuisanceTail.cs
@@ -8,6 +8,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHead))]
     public class DesertNuisanceTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHead.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceTail.cs
+++ b/NPCs/DesertScourge/DesertNuisanceTail.cs
@@ -8,7 +8,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertNuisanceHead))]
     public class DesertNuisanceTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHead.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceTailYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceTailYoung.cs
@@ -8,7 +8,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHeadYoung))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertNuisanceHeadYoung))]
     public class DesertNuisanceTailYoung : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHeadYoung.DisplayName");

--- a/NPCs/DesertScourge/DesertNuisanceTailYoung.cs
+++ b/NPCs/DesertScourge/DesertNuisanceTailYoung.cs
@@ -8,6 +8,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertNuisanceHeadYoung))]
     public class DesertNuisanceTailYoung : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertNuisanceHeadYoung.DisplayName");

--- a/NPCs/DesertScourge/DesertScourgeBody.cs
+++ b/NPCs/DesertScourge/DesertScourgeBody.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertScourgeHead))]
     public class DesertScourgeBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertScourgeHead.DisplayName");

--- a/NPCs/DesertScourge/DesertScourgeBody.cs
+++ b/NPCs/DesertScourge/DesertScourgeBody.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertScourgeHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertScourgeHead))]
     public class DesertScourgeBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertScourgeHead.DisplayName");

--- a/NPCs/DesertScourge/DesertScourgeHead.cs
+++ b/NPCs/DesertScourge/DesertScourgeHead.cs
@@ -32,6 +32,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class DesertScourgeHead : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertScourgeHead.cs
+++ b/NPCs/DesertScourge/DesertScourgeHead.cs
@@ -32,7 +32,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DesertScourge
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class DesertScourgeHead : ModNPC
     {
         private int biomeEnrageTimer = CalamityGlobalNPC.biomeEnrageTimerMax;

--- a/NPCs/DesertScourge/DesertScourgeTail.cs
+++ b/NPCs/DesertScourge/DesertScourgeTail.cs
@@ -10,7 +10,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DesertScourgeHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DesertScourgeHead))]
     public class DesertScourgeTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertScourgeHead.DisplayName");

--- a/NPCs/DesertScourge/DesertScourgeTail.cs
+++ b/NPCs/DesertScourge/DesertScourgeTail.cs
@@ -10,6 +10,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DesertScourge
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DesertScourgeHead))]
     public class DesertScourgeTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.DesertScourgeHead.DisplayName");

--- a/NPCs/DevourerofGods/CosmicGuardianBody.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianBody.cs
@@ -13,7 +13,7 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform(SyncWith = typeof(CosmicGuardianHead))]
+    [LongDistanceNetSync(SyncWith = typeof(CosmicGuardianHead))]
     public class CosmicGuardianBody : ModNPC
     {
         public int invinceTime = 180;

--- a/NPCs/DevourerofGods/CosmicGuardianBody.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianBody.cs
@@ -13,6 +13,7 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform(SyncWith = typeof(CosmicGuardianHead))]
     public class CosmicGuardianBody : ModNPC
     {
         public int invinceTime = 180;

--- a/NPCs/DevourerofGods/CosmicGuardianHead.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianHead.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class CosmicGuardianHead : ModNPC
     {
         private bool tail = false;

--- a/NPCs/DevourerofGods/CosmicGuardianHead.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianHead.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform]
     public class CosmicGuardianHead : ModNPC
     {
         private bool tail = false;

--- a/NPCs/DevourerofGods/CosmicGuardianTail.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianTail.cs
@@ -13,7 +13,7 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform(SyncWith = typeof(CosmicGuardianHead))]
+    [LongDistanceNetSync(SyncWith = typeof(CosmicGuardianHead))]
     public class CosmicGuardianTail : ModNPC
     {
         public int invinceTime = 180;

--- a/NPCs/DevourerofGods/CosmicGuardianTail.cs
+++ b/NPCs/DevourerofGods/CosmicGuardianTail.cs
@@ -13,6 +13,7 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform(SyncWith = typeof(CosmicGuardianHead))]
     public class CosmicGuardianTail : ModNPC
     {
         public int invinceTime = 180;

--- a/NPCs/DevourerofGods/DevourerofGodsBody.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsBody.cs
@@ -20,6 +20,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DevourerofGodsHead))]
     public class DevourerofGodsBody : ModNPC
     {
         public static int phase2IconIndex;

--- a/NPCs/DevourerofGods/DevourerofGodsBody.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsBody.cs
@@ -20,7 +20,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DevourerofGodsHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DevourerofGodsHead))]
     public class DevourerofGodsBody : ModNPC
     {
         public static int phase2IconIndex;

--- a/NPCs/DevourerofGods/DevourerofGodsHead.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsHead.cs
@@ -44,6 +44,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform]
     public class DevourerofGodsHead : ModNPC
     {
         public static int phase1IconIndex;

--- a/NPCs/DevourerofGods/DevourerofGodsHead.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsHead.cs
@@ -44,7 +44,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class DevourerofGodsHead : ModNPC
     {
         public static int phase1IconIndex;

--- a/NPCs/DevourerofGods/DevourerofGodsTail.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsTail.cs
@@ -19,7 +19,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
-    [AlwaysSyncTransform(SyncWith = typeof(DevourerofGodsHead))]
+    [LongDistanceNetSync(SyncWith = typeof(DevourerofGodsHead))]
     public class DevourerofGodsTail : ModNPC
     {
         public static int phase1IconIndex;

--- a/NPCs/DevourerofGods/DevourerofGodsTail.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsTail.cs
@@ -19,6 +19,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.DevourerofGods
 {
+    [AlwaysSyncTransform(SyncWith = typeof(DevourerofGodsHead))]
     public class DevourerofGodsTail : ModNPC
     {
         public static int phase1IconIndex;

--- a/NPCs/ExoMechs/Draedon.cs
+++ b/NPCs/ExoMechs/Draedon.cs
@@ -22,7 +22,7 @@ using ArtemisBoss = CalamityMod.NPCs.ExoMechs.Artemis.Artemis;
 
 namespace CalamityMod.NPCs.ExoMechs
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class Draedon : ModNPC
     {
         public int KillReappearTextCountdown;

--- a/NPCs/ExoMechs/Draedon.cs
+++ b/NPCs/ExoMechs/Draedon.cs
@@ -22,6 +22,7 @@ using ArtemisBoss = CalamityMod.NPCs.ExoMechs.Artemis.Artemis;
 
 namespace CalamityMod.NPCs.ExoMechs
 {
+    [AlwaysSyncTransform]
     public class Draedon : ModNPC
     {
         public int KillReappearTextCountdown;

--- a/NPCs/ExoMechs/Thanatos/ThanatosBody1.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosBody1.cs
@@ -17,7 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
-    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
+    [LongDistanceNetSync(SyncWith = typeof(ThanatosHead))]
     public class ThanatosBody1 : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosBody1.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosBody1.cs
@@ -17,6 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
+    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
     public class ThanatosBody1 : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosBody2.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosBody2.cs
@@ -17,6 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
+    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
     public class ThanatosBody2 : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosBody2.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosBody2.cs
@@ -17,7 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
-    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
+    [LongDistanceNetSync(SyncWith = typeof(ThanatosHead))]
     public class ThanatosBody2 : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosHead.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosHead.cs
@@ -22,6 +22,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
+    [AlwaysSyncTransform]
     public class ThanatosHead : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosHead.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosHead.cs
@@ -22,7 +22,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class ThanatosHead : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosTail.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosTail.cs
@@ -17,7 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
-    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
+    [LongDistanceNetSync(SyncWith = typeof(ThanatosHead))]
     public class ThanatosTail : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/ExoMechs/Thanatos/ThanatosTail.cs
+++ b/NPCs/ExoMechs/Thanatos/ThanatosTail.cs
@@ -17,6 +17,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.ExoMechs.Thanatos
 {
+    [AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
     public class ThanatosTail : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/LongDistanceNetSyncAttribute.cs
+++ b/NPCs/LongDistanceNetSyncAttribute.cs
@@ -11,7 +11,7 @@ namespace CalamityMod.NPCs
     /// This attribute allows ModNPC to always sync for their position and rotation data at least every 45 frames
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class AlwaysSyncTransformAttribute : Attribute
+    public sealed class LongDistanceNetSyncAttribute : Attribute
     {
         /// <summary>
         /// Syncs this NPC to other NPC's sync frame
@@ -19,7 +19,7 @@ namespace CalamityMod.NPCs
         /// </summary>
         public Type SyncWith { get; set; } = null;
 
-        public AlwaysSyncTransformAttribute()
+        public LongDistanceNetSyncAttribute()
         {
 
         }

--- a/NPCs/NormalNPCs/ArmoredDiggerBody.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerBody.cs
@@ -10,7 +10,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
-    [AlwaysSyncTransform(SyncWith = typeof(ArmoredDiggerHead))]
+    [LongDistanceNetSync(SyncWith = typeof(ArmoredDiggerHead))]
     public class ArmoredDiggerBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.ArmoredDiggerHead.DisplayName");

--- a/NPCs/NormalNPCs/ArmoredDiggerBody.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerBody.cs
@@ -10,6 +10,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
+    [AlwaysSyncTransform(SyncWith = typeof(ArmoredDiggerHead))]
     public class ArmoredDiggerBody : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.ArmoredDiggerHead.DisplayName");

--- a/NPCs/NormalNPCs/ArmoredDiggerHead.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerHead.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
+    [AlwaysSyncTransform]
     public class ArmoredDiggerHead : ModNPC
     {
         bool TailSpawned = false;

--- a/NPCs/NormalNPCs/ArmoredDiggerHead.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerHead.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class ArmoredDiggerHead : ModNPC
     {
         bool TailSpawned = false;

--- a/NPCs/NormalNPCs/ArmoredDiggerTail.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerTail.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
-    [AlwaysSyncTransform(SyncWith = typeof(ArmoredDiggerHead))]
+    [LongDistanceNetSync(SyncWith = typeof(ArmoredDiggerHead))]
     public class ArmoredDiggerTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.ArmoredDiggerHead.DisplayName");

--- a/NPCs/NormalNPCs/ArmoredDiggerTail.cs
+++ b/NPCs/NormalNPCs/ArmoredDiggerTail.cs
@@ -9,6 +9,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.NormalNPCs
 {
+    [AlwaysSyncTransform(SyncWith = typeof(ArmoredDiggerHead))]
     public class ArmoredDiggerTail : ModNPC
     {
         public override LocalizedText DisplayName => CalamityUtils.GetText("NPCs.ArmoredDiggerHead.DisplayName");

--- a/NPCs/Perforator/PerforatorBodyLarge.cs
+++ b/NPCs/Perforator/PerforatorBodyLarge.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadLarge))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadLarge))]
     public class PerforatorBodyLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorBodyLarge.cs
+++ b/NPCs/Perforator/PerforatorBodyLarge.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadLarge))]
     public class PerforatorBodyLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorBodyMedium.cs
+++ b/NPCs/Perforator/PerforatorBodyMedium.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadMedium))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadMedium))]
     public class PerforatorBodyMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorBodyMedium.cs
+++ b/NPCs/Perforator/PerforatorBodyMedium.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadMedium))]
     public class PerforatorBodyMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorBodySmall.cs
+++ b/NPCs/Perforator/PerforatorBodySmall.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadSmall))]
     public class PerforatorBodySmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/Perforator/PerforatorBodySmall.cs
+++ b/NPCs/Perforator/PerforatorBodySmall.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadSmall))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadSmall))]
     public class PerforatorBodySmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/Perforator/PerforatorHeadLarge.cs
+++ b/NPCs/Perforator/PerforatorHeadLarge.cs
@@ -17,6 +17,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class PerforatorHeadLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorHeadLarge.cs
+++ b/NPCs/Perforator/PerforatorHeadLarge.cs
@@ -17,7 +17,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class PerforatorHeadLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorHeadMedium.cs
+++ b/NPCs/Perforator/PerforatorHeadMedium.cs
@@ -16,7 +16,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class PerforatorHeadMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorHeadMedium.cs
+++ b/NPCs/Perforator/PerforatorHeadMedium.cs
@@ -16,6 +16,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class PerforatorHeadMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorHeadSmall.cs
+++ b/NPCs/Perforator/PerforatorHeadSmall.cs
@@ -16,6 +16,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class PerforatorHeadSmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/Perforator/PerforatorHeadSmall.cs
+++ b/NPCs/Perforator/PerforatorHeadSmall.cs
@@ -16,7 +16,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.Perforator
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class PerforatorHeadSmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/Perforator/PerforatorTailLarge.cs
+++ b/NPCs/Perforator/PerforatorTailLarge.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadLarge))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadLarge))]
     public class PerforatorTailLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorTailLarge.cs
+++ b/NPCs/Perforator/PerforatorTailLarge.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadLarge))]
     public class PerforatorTailLarge : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfLargeHit", 3);

--- a/NPCs/Perforator/PerforatorTailMedium.cs
+++ b/NPCs/Perforator/PerforatorTailMedium.cs
@@ -15,7 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadMedium))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadMedium))]
     public class PerforatorTailMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorTailMedium.cs
+++ b/NPCs/Perforator/PerforatorTailMedium.cs
@@ -15,6 +15,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadMedium))]
     public class PerforatorTailMedium : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfMediumHit", 3);

--- a/NPCs/Perforator/PerforatorTailSmall.cs
+++ b/NPCs/Perforator/PerforatorTailSmall.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadSmall))]
     public class PerforatorTailSmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/Perforator/PerforatorTailSmall.cs
+++ b/NPCs/Perforator/PerforatorTailSmall.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.Perforator
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PerforatorHeadSmall))]
+    [LongDistanceNetSync(SyncWith = typeof(PerforatorHeadSmall))]
     public class PerforatorTailSmall : ModNPC
     {
         public static readonly SoundStyle HitSound = new("CalamityMod/Sounds/NPCHit/PerfSmallHit", 3);

--- a/NPCs/PrimordialWyrm/PrimordialWyrmBody.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmBody.cs
@@ -12,7 +12,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmBody : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/PrimordialWyrm/PrimordialWyrmBody.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmBody.cs
@@ -12,6 +12,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmBody : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/PrimordialWyrm/PrimordialWyrmBodyAlt.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmBodyAlt.cs
@@ -12,6 +12,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmBodyAlt : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/PrimordialWyrm/PrimordialWyrmBodyAlt.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmBodyAlt.cs
@@ -12,7 +12,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmBodyAlt : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
@@ -28,6 +28,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
     [AutoloadBossHead]
+    [AlwaysSyncTransform]
     public class PrimordialWyrmHead : ModNPC
     {
         public enum Phase

--- a/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
@@ -28,7 +28,7 @@ using Terraria.ModLoader;
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
     [AutoloadBossHead]
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class PrimordialWyrmHead : ModNPC
     {
         public enum Phase

--- a/NPCs/PrimordialWyrm/PrimordialWyrmTail.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmTail.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
+    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmTail : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/PrimordialWyrm/PrimordialWyrmTail.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmTail.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.PrimordialWyrm
 {
-    [AlwaysSyncTransform(SyncWith = typeof(PrimordialWyrmHead))]
+    [LongDistanceNetSync(SyncWith = typeof(PrimordialWyrmHead))]
     public class PrimordialWyrmTail : ModNPC
     {
         public static Asset<Texture2D> GlowTexture;

--- a/NPCs/StormWeaver/StormWeaverBody.cs
+++ b/NPCs/StormWeaver/StormWeaverBody.cs
@@ -14,7 +14,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
-    [AlwaysSyncTransform(SyncWith = typeof(StormWeaverHead))]
+    [LongDistanceNetSync(SyncWith = typeof(StormWeaverHead))]
     public class StormWeaverBody : ModNPC
     {
         public static Asset<Texture2D> Phase2Texture;

--- a/NPCs/StormWeaver/StormWeaverBody.cs
+++ b/NPCs/StormWeaver/StormWeaverBody.cs
@@ -14,6 +14,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
+    [AlwaysSyncTransform(SyncWith = typeof(StormWeaverHead))]
     public class StormWeaverBody : ModNPC
     {
         public static Asset<Texture2D> Phase2Texture;

--- a/NPCs/StormWeaver/StormWeaverHead.cs
+++ b/NPCs/StormWeaver/StormWeaverHead.cs
@@ -31,7 +31,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class StormWeaverHead : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/StormWeaver/StormWeaverHead.cs
+++ b/NPCs/StormWeaver/StormWeaverHead.cs
@@ -31,6 +31,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
+    [AlwaysSyncTransform]
     public class StormWeaverHead : ModNPC
     {
         public static int normalIconIndex;

--- a/NPCs/StormWeaver/StormWeaverTail.cs
+++ b/NPCs/StormWeaver/StormWeaverTail.cs
@@ -13,6 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
+    [AlwaysSyncTransform(SyncWith = typeof(StormWeaverHead))]
     public class StormWeaverTail : ModNPC
     {
         private int invinceTime = 180;

--- a/NPCs/StormWeaver/StormWeaverTail.cs
+++ b/NPCs/StormWeaver/StormWeaverTail.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.StormWeaver
 {
-    [AlwaysSyncTransform(SyncWith = typeof(StormWeaverHead))]
+    [LongDistanceNetSync(SyncWith = typeof(StormWeaverHead))]
     public class StormWeaverTail : ModNPC
     {
         private int invinceTime = 180;

--- a/NPCs/SupremeCalamitas/SepulcherBody.cs
+++ b/NPCs/SupremeCalamitas/SepulcherBody.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
+    [AlwaysSyncTransform(SyncWith = typeof(SepulcherHead))]
     public class SepulcherBody : ModNPC
     {
         private bool setAlpha = false;

--- a/NPCs/SupremeCalamitas/SepulcherBody.cs
+++ b/NPCs/SupremeCalamitas/SepulcherBody.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
-    [AlwaysSyncTransform(SyncWith = typeof(SepulcherHead))]
+    [LongDistanceNetSync(SyncWith = typeof(SepulcherHead))]
     public class SepulcherBody : ModNPC
     {
         private bool setAlpha = false;

--- a/NPCs/SupremeCalamitas/SepulcherHead.cs
+++ b/NPCs/SupremeCalamitas/SepulcherHead.cs
@@ -16,7 +16,7 @@ using static Humanizer.In;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
-    [AlwaysSyncTransform]
+    [LongDistanceNetSync]
     public class SepulcherHead : ModNPC
     {
         public static readonly SoundStyle DeathSound = new("CalamityMod/Sounds/NPCKilled/SepulcherDeath");

--- a/NPCs/SupremeCalamitas/SepulcherHead.cs
+++ b/NPCs/SupremeCalamitas/SepulcherHead.cs
@@ -16,6 +16,7 @@ using static Humanizer.In;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
+    [AlwaysSyncTransform]
     public class SepulcherHead : ModNPC
     {
         public static readonly SoundStyle DeathSound = new("CalamityMod/Sounds/NPCKilled/SepulcherDeath");

--- a/NPCs/SupremeCalamitas/SepulcherTail.cs
+++ b/NPCs/SupremeCalamitas/SepulcherTail.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
+    [AlwaysSyncTransform(SyncWith = typeof(SepulcherHead))]
     public class SepulcherTail : ModNPC
     {
         private bool setAlpha = false;

--- a/NPCs/SupremeCalamitas/SepulcherTail.cs
+++ b/NPCs/SupremeCalamitas/SepulcherTail.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader;
 
 namespace CalamityMod.NPCs.SupremeCalamitas
 {
-    [AlwaysSyncTransform(SyncWith = typeof(SepulcherHead))]
+    [LongDistanceNetSync(SyncWith = typeof(SepulcherHead))]
     public class SepulcherTail : ModNPC
     {
         private bool setAlpha = false;


### PR DESCRIPTION
## Related to: #61 (Head-only WormBoss PR)
Instead of hardcode every NPCType in CalamityNetImportantNPC, It will now check for `[AlwaysSyncTransform]` attribute

## Attribute Usage Example:
### Normal Case:
```cs
// By adding this attribute this NPC now sync it's Position and Rotation every 45 frames
// This could be added to bosses that never despawn by distance
// For single bosses it mostly works without this attribute.
// But adding this will sync it's head icon on map instead of stop in one place
[AlwaysSyncTransform]
public class Cryogen : ModNPC {}
```

### WormBoss Case:
```cs
// Head Type:
[AlwaysSyncTransform]
public class ThanatosHead : ModNPC {}

// Body Parts:
// SyncWith Property is provided to set sync timing to same as given type
// Without setting SyncWith, each bodypart will have different net update offset, therefore it might cause issue like teleporting icons on map
[AlwaysSyncTransform(SyncWith = typeof(ThanatosHead))]
public class ThanatosTail : ModNPC {}
```

## Naming Question:
There was few candidate for Attribute name and I want to ask which one should be used:
- `AlwaysSyncTransform` *Current one*
- `EnsureSyncTransform`
- `AutoSyncTransform`
- `MarkAsNetImportant`
- `SyncTransform`
