### PR TITLE
Spine tree now drops correctly in multiplayer

### DIFF
--- a/Tiles/Crags/Tree/SpineTree.cs
+++ b/Tiles/Crags/Tree/SpineTree.cs
@@ -153,6 +153,10 @@ namespace CalamityMod.Tiles.Crags.Tree
             if (!Framing.GetTileSafely(i, j + 1).HasTile)
             {
                 WorldGen.KillTile(i, j, false, false, false);
+                if (Main.netMode == NetmodeID.MultiplayerClient)
+                {
+                    NetMessage.SendData(MessageID.TileManipulation, -1, -1, null, 0, i, j);
+                }
             }
         }
 


### PR DESCRIPTION
Plain `KillTile` in a `MultiplayerClient` doesn't drop any item. This causes spine trees to drop items only for the directly broken tile. This commit solves the issue.