### PR TITLE
Fixed desync problem of plantera thorn balls

### DIFF
--- a/NPCs/VanillaNPCAIOverrides/Bosses/PlanteraAI.cs
+++ b/NPCs/VanillaNPCAIOverrides/Bosses/PlanteraAI.cs
@@ -235,9 +235,10 @@ namespace CalamityMod.NPCs.VanillaNPCAIOverrides.Bosses
 
                         if (Main.netMode != NetmodeID.MultiplayerClient)
                         {
-                            int proj = Projectile.NewProjectile(npc.GetSource_FromAI(), adjustProjectileShootLocation ? npc.Center : spawnOffset, projectileVelocity * projectileSpeed, projectileType, damage, 0f, Main.myPlayer);
+                            float ai2 = 0f;
                             if (projectileType == ProjectileID.ThornBall && (Main.rand.NextBool() || !Main.zenithWorld))
-                                Main.projectile[proj].tileCollide = false;
+                                ai2 = 1f;
+                            Projectile.NewProjectile(npc.GetSource_FromAI(), adjustProjectileShootLocation ? npc.Center : spawnOffset, projectileVelocity * projectileSpeed, projectileType, damage, 0f, Main.myPlayer, 0f, 0f, ai2);
                         }
                     }
                 }
@@ -800,9 +801,10 @@ namespace CalamityMod.NPCs.VanillaNPCAIOverrides.Bosses
 
                                 if (Main.netMode != NetmodeID.MultiplayerClient)
                                 {
-                                    int proj = Projectile.NewProjectile(npc.GetSource_FromAI(), spawnOffset, projectileVelocity * projectileSpeed, type, damage, 0f, Main.myPlayer);
+                                    float ai2 = 0f;
                                     if (Main.rand.NextBool() || !Main.zenithWorld)
-                                        Main.projectile[proj].tileCollide = false;
+                                        ai2 = 1f;
+                                    Projectile.NewProjectile(npc.GetSource_FromAI(), spawnOffset, projectileVelocity * projectileSpeed, type, damage, 0f, Main.myPlayer, 0f, 0f, ai2);
                                 }
                             }
                         }

--- a/Projectiles/CalamityGlobalProjectile.cs
+++ b/Projectiles/CalamityGlobalProjectile.cs
@@ -2639,8 +2639,9 @@ namespace CalamityMod.Projectiles
                     return false;
                 }
 
-                else if (projectile.type == ProjectileID.ThornBall && !projectile.tileCollide)
+                else if (projectile.type == ProjectileID.ThornBall && projectile.ai[2] != 0)
                 {
+                    projectile.tileCollide = false;
                     if (projectile.alpha > 0)
                     {
                         projectile.alpha -= 30;


### PR DESCRIPTION
Original code utilizes projectile's `tileCollide` to alter the behaviour, and this field is never synced back to clients. This makes clients simulate the vanilla thorn ball behaviour thus observing thorn ball spikes appearing out of nowhere. I instead utilized `ai[2]` slot which is currently unused for this projectile and definitely synced back to the clients.