### PR TITLE
Fixed Fargo's Mutant AddIndestructibleRectangle modcall using tile coords instead of world coords

### DIFF
--- a/Utilities/WorldgenUtils.cs
+++ b/Utilities/WorldgenUtils.cs
@@ -155,6 +155,10 @@ namespace CalamityMod
 
             // If Fargo's Mutant Mod is loaded, add to their Indestructible Rectangle list, which prevents structures from being trashed by Fargo's terrain tools.
             Mod fargos = CalamityMod.Instance.fargos;
+            paddedArea.X *= 16;
+            paddedArea.Y *= 16;
+            paddedArea.Width *= 16;
+            paddedArea.Height *= 16;
             fargos?.Call("AddIndestructibleRectangle", paddedArea);
         }
     }


### PR DESCRIPTION
Small fuckup on my part

Doing it this way rather than changing the modcall to use tile coordinates because there's many other mods that rely on it, using world coords, and it's easier to change this one implementation than all of the other ones