### PR TITLE
Changed Mechworm segment logic

### DIFF
--- a/Projectiles/Summon/MechwormHead.cs
+++ b/Projectiles/Summon/MechwormHead.cs
@@ -448,7 +448,7 @@ namespace CalamityMod.Projectiles.Summon
                 if (segments.ContainsKey(i))
                 {
                     SpriteEffects fx = Math.Abs(segments[i].rotation) > MathHelper.PiOver2 ? SpriteEffects.FlipHorizontally : SpriteEffects.None;
-                    if (i < segments.Count - 1)
+                    if (i < segments.Count)
                     {
                         Main.EntitySpriteDraw(texBody, segments[i].Center - Main.screenPosition, null, segments[i].GetAlpha(lightColor), segments[i].rotation + MathHelper.Pi / 2f, texBody.Size() / (2f), segments[i].scale, fx, 0);
                     }


### PR DESCRIPTION
Adjusted the segment logic used by Mechworm to match Tenryu's logic. This removes the gaps between segments caused by high speed movement.

Multiplayer has a similar issue as Tenryu does (body segments not showing up). not quite sure why that happens or how to solve it, but it doesn't cause any issues I could find besides how it appears visually.