### PR TITLE
Fix AstralOre oob error

### DIFF
--- a/Tiles/Ores/AstralOre.cs
+++ b/Tiles/Ores/AstralOre.cs
@@ -42,6 +42,8 @@ namespace CalamityMod.Tiles.Ores
         }
         public override void NearbyEffects(int i, int j, bool closer)
         {
+            if (j < 2)
+                return; 
             Tile tile = Main.tile[i, j];
             Tile up = Main.tile[i, j - 1];
             Tile up2 = Main.tile[i, j - 2];


### PR DESCRIPTION
I don't know how it happens, but some users seem to have an AstralOre tile at `Main.tile[0, 0]`, which crashes when the world is entered. This extra check prevents that.

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at CalamityMod.Tiles.Ores.AstralOre.NearbyEffects(Int32 i, Int32 j, Boolean closer) in CalamityMod\Tiles\Ores\AstralOre.cs:line 46
   at Terraria.ModLoader.TileLoader.NearbyEffects(Int32 i, Int32 j, Int32 type, Boolean closer) in tModLoader\Terraria\ModLoader\TileLoader.cs:line 659
   at Terraria.SceneMetrics.ScanAndExportToMain(SceneMetricsScanSettings settings) in tModLoader\Terraria\SceneMetrics.cs:line 299
   at Terraria.Graphics.Light.LightingEngine.ProcessArea(Rectangle area) in tModLoader\Terraria\Graphics\Light\LightingEngine.cs:line 81
   at Terraria.Lighting.LightTiles(Int32 firstX, Int32 lastX, Int32 firstY, Int32 lastY) in tModLoader\Terraria\Lighting.cs:line 90
   at DMD<System.Void Terraria.Main:DoDraw(Microsoft.Xna.Framework.GameTime)>(Main this, GameTime gameTime)
   at SyncProxy<System.Void Terraria.Main:DoDraw(Microsoft.Xna.Framework.GameTime)>(Main , GameTime )
   at Terraria.Main.Draw_Inner(GameTime gameTime)
```