### PR TITLE
Valhalla Regen bugfix

### DIFF
--- a/Items/CalamityGlobalItem.cs
+++ b/Items/CalamityGlobalItem.cs
@@ -1129,7 +1129,7 @@ namespace CalamityMod.Items
                     break;
 
                 case ItemID.SquireAltShirt:
-                    player.lifeRegen -= 6;
+                    player.lifeRegen -= 2;
                     break;
                 case ItemID.SquireAltPants:
                     player.GetDamage<SummonDamageClass>() -= 0.1f;

--- a/Items/CalamityGlobalItem.cs
+++ b/Items/CalamityGlobalItem.cs
@@ -1026,7 +1026,7 @@ namespace CalamityMod.Items
             }
             else if (set == "SquireTier3")
             {
-                player.lifeRegen += 6;
+                player.lifeRegen += 2;
                 player.GetDamage<SummonDamageClass>() += 0.1f;
                 player.GetCritChance<MeleeDamageClass>() += 10;
                 player.setBonus += $"\n{CalamityUtils.GetTextValue("Vanilla.Armor.SetBonus.SquireTier3")}";

--- a/Items/CalamityGlobalItemTooltip.cs
+++ b/Items/CalamityGlobalItemTooltip.cs
@@ -943,7 +943,7 @@ namespace CalamityMod.Items
             // Reduce DD2 armor piece bonuses because they're overpowered, and clarify life regen boosts
             // Squire armor
             if (item.type == ItemID.SquireGreatHelm)
-                EditTooltipByNum(0, (line) => line.Text = "Increases your max number of sentries by 1 and grants +2 HP/s life regen");
+                EditTooltipByNum(0, (line) => line.Text = "Increases your max number of sentries by 1 and grants +1 HP/s life regen");
             if (item.type == ItemID.SquirePlating)
                 EditTooltipByNum(0, (line) => line.Text = "10% increased minion and melee damage");
             if (item.type == ItemID.SquireGreaves)


### PR DESCRIPTION
in vanilla 1.4.0.1, Valhalla Knight was reduced from 8 regen to 4 regen. Calamity's move of stats to the set bonus was not adjusted to compensate, leaving the set bonus giving +6 regen while the chestplate alone now gives -2 regen, for the vanilla total of 4.

Fixed that, causing both set bonus and chestplate to give +2 regen each, no longer causing negative regeneration when wearing just the chestplate.