### PR TITLE
Tweaked mode selector ui to fix an inconsistency between the bg and the text when it grows beyond screen width

### DIFF
--- a/UI/ModeIndicator/ModeIndicatorUI.cs
+++ b/UI/ModeIndicator/ModeIndicatorUI.cs
@@ -184,8 +184,8 @@ namespace CalamityMod.UI.ModeIndicator
                 if (!Main.mouseItem.IsAir)
                     textboxStart.X += 34;
 
-                if (textboxStart.X + boxSize.X + 4f > (float)Main.screenWidth)
-                    textboxStart.X = Main.screenWidth - boxSize.X - 4f;
+                if (textboxStart.X + regexedBoxSize.X + 4f > (float)Main.screenWidth)
+                    textboxStart.X = Main.screenWidth - regexedBoxSize.X - 4f;
 
                 if (textboxStart.Y + regexedBoxSize.Y + 4f > (float)Main.screenHeight)
                     textboxStart.Y = Main.screenHeight - regexedBoxSize.Y - 4f;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/6f5f90bc-0bd2-4aef-9cb8-3ad484da6dee)
After:
![image](https://github.com/user-attachments/assets/0bba9308-cec5-4f90-9fa2-51ed8c2dee1e)

Not tested on other screen resolutions, so please test this 
