### PR TITLE
Fix Plaguebringer Armor's Hive Pack interaction

### DIFF
--- a/Projectiles/Summon/PlaguebringerSummon.cs
+++ b/Projectiles/Summon/PlaguebringerSummon.cs
@@ -81,7 +81,7 @@ namespace CalamityMod.Projectiles.Summon
                         Projectile bee = Projectile.NewProjectileDirect(Projectile.GetSource_FromThis(), Projectile.Center, Main.rand.NextVector2Circular(0.25f, 0.25f), beeType, Owner.beeDamage(Projectile.damage), Owner.beeKB(0f), Projectile.owner);
                         bee.usesLocalNPCImmunity = true;
                         bee.localNPCHitCooldown = 10;
-                        bee.penetrate = 2;
+                        bee.penetrate = (beeType == ProjectileID.GiantBee ? 3 : 2);
                         bee.DamageType = DamageClass.Generic;
                     }
                 }


### PR DESCRIPTION
Hive pack giant bees normally have 1 more pierce than regular bees, but Plaguebringer armor sets the penetrate of all bees it spawns to 2. Made it set Giant Bees's penetrate to 3 instead of 2 to maintain this functionality, as it's the majority of where the difference in Giant Bees vs regular Bees comes from.