### PR TITLE
Multiple minion slots support for Summoner's Association

### DIFF
--- a/Items/Weapons/Summon/CosmicImmaterializer.cs
+++ b/Items/Weapons/Summon/CosmicImmaterializer.cs
@@ -32,6 +32,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.DamageType = DamageClass.Summon;
             Item.rare = ModContent.RarityType<Violet>();
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 10;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0 && player.maxMinions >= 10;
 

--- a/Items/Weapons/Summon/Cosmilamp.cs
+++ b/Items/Weapons/Summon/Cosmilamp.cs
@@ -38,6 +38,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.DamageType = DamageClass.Summon;
         }
 
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 2;
+        }
+
         public override bool CanUseItem(Player player) => player.maxMinions >= 2;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Items/Weapons/Summon/DragonbloodDisgorger.cs
+++ b/Items/Weapons/Summon/DragonbloodDisgorger.cs
@@ -29,6 +29,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.shootSpeed = 10f;
             Item.DamageType = DamageClass.Summon;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 6;
+        }
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Items/Weapons/Summon/Endogenesis.cs
+++ b/Items/Weapons/Summon/Endogenesis.cs
@@ -19,6 +19,7 @@ namespace CalamityMod.Items.Weapons.Summon
         public override void SetStaticDefaults()
         {
             //Icy no problems with that
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 10;
         }
 
         public override void SetDefaults()

--- a/Items/Weapons/Summon/InfectedRemote.cs
+++ b/Items/Weapons/Summon/InfectedRemote.cs
@@ -51,6 +51,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.rare = ItemRarityID.Yellow;
             Item.Calamity().donorItem = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 3;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0;
 

--- a/Items/Weapons/Summon/KingofConstellationsTenryu.cs
+++ b/Items/Weapons/Summon/KingofConstellationsTenryu.cs
@@ -35,6 +35,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.DamageType = DamageClass.Summon;
             Item.autoReuse = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 2;
+        }
 
         public override Vector2? HoldoutOffset()
         {

--- a/Items/Weapons/Summon/LiliesOfFinality.cs
+++ b/Items/Weapons/Summon/LiliesOfFinality.cs
@@ -54,6 +54,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.useStyle = ItemUseStyleID.HoldUp;
             Item.UseSound = new("CalamityMod/Sounds/Item/LiliesOfFinalitySummonSpawn");
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 2;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] == 0 && player.maxMinions - player.slotsMinions >= 2;
 

--- a/Items/Weapons/Summon/Metastasis.cs
+++ b/Items/Weapons/Summon/Metastasis.cs
@@ -32,6 +32,7 @@ namespace CalamityMod.Items.Weapons.Summon
         public override void SetStaticDefaults()
         {
             ItemID.Sets.ShimmerTransformToItem[Type] = ModContent.ItemType<StaffoftheMechworm>();
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 4;
         }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0;

--- a/Items/Weapons/Summon/MutatedTruffle.cs
+++ b/Items/Weapons/Summon/MutatedTruffle.cs
@@ -46,6 +46,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.rare = ModContent.RarityType<PureGreen>();
             Item.value = CalamityGlobalItem.RarityPureGreenBuyPrice;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 3;
+        }
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Items/Weapons/Summon/Perdition.cs
+++ b/Items/Weapons/Summon/Perdition.cs
@@ -30,6 +30,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.useStyle = ItemUseStyleID.Swing;
             Item.UseSound = SoundID.DD2_EtherianPortalOpen;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 5;
+        }
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Items/Weapons/Summon/PlantationStaff.cs
+++ b/Items/Weapons/Summon/PlantationStaff.cs
@@ -50,6 +50,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.useStyle = ItemUseStyleID.Swing;
             Item.UseSound = SoundID.Item76;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 3;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0;
 

--- a/Items/Weapons/Summon/SarosPossession.cs
+++ b/Items/Weapons/Summon/SarosPossession.cs
@@ -29,6 +29,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.value = CalamityGlobalItem.RarityDarkBlueBuyPrice;
             Item.noMelee = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 8;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0 && player.maxMinions >= 8;
 

--- a/Items/Weapons/Summon/ShellfishStaff.cs
+++ b/Items/Weapons/Summon/ShellfishStaff.cs
@@ -29,6 +29,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.DamageType = DamageClass.Summon;
         }
 
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 2;
+        }
+
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {
             if (player.altFunctionUse != 2)

--- a/Items/Weapons/Summon/Sirius.cs
+++ b/Items/Weapons/Summon/Sirius.cs
@@ -28,6 +28,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.value = CalamityGlobalItem.RarityPureGreenBuyPrice;
             Item.noMelee = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 6;
+        }
 
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0 && player.maxMinions >= 6;
 

--- a/Items/Weapons/Summon/TemporalUmbrella.cs
+++ b/Items/Weapons/Summon/TemporalUmbrella.cs
@@ -33,6 +33,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.rare = ModContent.RarityType<HotPink>();
             Item.Calamity().devItem = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 5;
+        }
 
         public override bool CanUseItem(Player player) => player.maxMinions >= 5;
 

--- a/Items/Weapons/Summon/VoidConcentrationStaff.cs
+++ b/Items/Weapons/Summon/VoidConcentrationStaff.cs
@@ -29,6 +29,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.value = CalamityGlobalItem.RarityTurquoiseBuyPrice;
             Item.rare = ModContent.RarityType<Turquoise>();
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 3;
+        }
 
         public override bool CanUseItem(Player player)
         {

--- a/Items/Weapons/Summon/WarloksMoonFist.cs
+++ b/Items/Weapons/Summon/WarloksMoonFist.cs
@@ -38,6 +38,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.DamageType = DamageClass.Summon;
             Item.Calamity().donorItem = true;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 4;
+        }
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Items/Weapons/Summon/YharonsKindleStaff.cs
+++ b/Items/Weapons/Summon/YharonsKindleStaff.cs
@@ -32,6 +32,11 @@ namespace CalamityMod.Items.Weapons.Summon
             Item.shootSpeed = 10f;
             Item.DamageType = DamageClass.Summon;
         }
+        
+        public override void SetStaticDefaults()
+        {
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 5;
+        }
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {


### PR DESCRIPTION
## Description

While playing Calamity along with Summoner's Association, a common problem when using `Minion Loadout Book`/`Automatic Minion Loadout Book` is that some minions use multiple minion slots. The UI is not aware of that and simulates the used/remaining slots as if every summoner item used exactly 1 slot, often bringing results that differ from the reality.

In this demonstration, you can see 2 minions being used:
- 1x Endogenesis staff (consumes 10 minion slots, 10 x 1 = 10 minion slots used in total)
- 2x Yharon's Kindle Staff (consumes 5 minion slots, 5 x 2 = 10 minion slots used in total)

Usually the mod would display 3/21 slots being used, however with this PR it correctly displays 20/21 slots being used, synced with the Summoner UI output.

| Before | After |
| :- | :- |
| ![image](https://github.com/user-attachments/assets/945256ba-acc9-46a7-9368-5c6eb9255ac9) | ![image](https://github.com/user-attachments/assets/c8033c31-d13f-4d41-8649-bca1afd13426) |

Those are the summons fixed by this PR, they were very easy to fix since they always consume a fixed amount of minion slots, it was just a matter of defining `StaffMinionSlotsRequired` to the amount of minion slots they consume:
- Cosmic Immaterializer
- Cosmilamp
- Dragonblood Disgorger
- Endogenesis
- Infected Remote
- King of Constellations, Tenryu
- Lilies of Finality
- Metastasis
- Mutated Truffle
- Perdition
- Plantation Staff
- Saros Possession
- Shellfish Staff
- Sirius
- Temporal Umbrella
- Void Concentration Staff
- Warloks' Moon Fist
- Yharon's Kindle Staff

## Limitations

Even though this PR correctly displays minion slots consumed for most minions, there are a bunch of summons that are more complex to deal with since they have conditional behavior where they take X slots if current minion slots >= X, otherwise take up Y slots. For those cases I just let the `StaffMinionSlotsRequired` property equal to the minimum amount of minions required by each staff. Those are the summons that fall within this category:

- Wither Blossom Staff: conditional behavior of 1-2 slots
- Entropy's Vigil: conditional behavior of 1-2 slots
- Flowers of Mortality: conditional behavior of 1-3 slots
- King of Constellations, Tenryu: conditional behavior of 2-4 slots

There are other 2 specific summons that this PR doesn't cover because they would be exceptionally hard to handle:

- Ares' Exoskeleton: configurable within a very unique UI, may use up 0 to 12 slots
- Abandoned slime staff: like conditional behavior but even worse, the amount of slots used is relative to the slots available

It kinda sucks that this PR doesn't fix the behavior for all the summons, but I'm happy that at least it's enough to fix the minion usage displayed for most summoner weapons with multiple minions slots.

Initially this would be a PR for summoner's association, but later on direwolf instructed me that it made more sense to implement it on calamity's end: https://github.com/JavidPack/SummonersAssociation/pull/25