### PR TITLE
Fix Aureate Booster and MOAB playing wing flap sounds

### DIFF
--- a/Items/Accessories/Wings/AureateBooster.cs
+++ b/Items/Accessories/Wings/AureateBooster.cs
@@ -30,6 +30,8 @@ namespace CalamityMod.Items.Accessories.Wings
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
+            player.DisableDefaultWingFlapSound();
+
             if (player.controlJump && player.wingTime > 0f && player.jump == 0 && player.velocity.Y != 0f && !hideVisual)
             {
                 player.rocketDelay2--;

--- a/Items/Accessories/Wings/AureateBooster.cs
+++ b/Items/Accessories/Wings/AureateBooster.cs
@@ -30,7 +30,7 @@ namespace CalamityMod.Items.Accessories.Wings
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
-            player.DisableDefaultWingFlapSound();
+            player.DisableWingFlapSound();
 
             if (player.controlJump && player.wingTime > 0f && player.jump == 0 && player.velocity.Y != 0f && !hideVisual)
             {

--- a/Items/Accessories/Wings/MOAB.cs
+++ b/Items/Accessories/Wings/MOAB.cs
@@ -28,7 +28,7 @@ namespace CalamityMod.Items.Accessories.Wings
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
-            player.DisableDefaultWingFlapSound();
+            player.DisableWingFlapSound();
           
             if (player.controlJump && player.wingTime > 0f && player.jump == 0 && player.velocity.Y != 0f && !hideVisual)
             {

--- a/Items/Accessories/Wings/MOAB.cs
+++ b/Items/Accessories/Wings/MOAB.cs
@@ -28,6 +28,8 @@ namespace CalamityMod.Items.Accessories.Wings
 
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
+            player.DisableDefaultWingFlapSound();
+          
             if (player.controlJump && player.wingTime > 0f && player.jump == 0 && player.velocity.Y != 0f && !hideVisual)
             {
                 player.rocketDelay2--;

--- a/Utilities/PlayerUtils.cs
+++ b/Utilities/PlayerUtils.cs
@@ -324,11 +324,14 @@ namespace CalamityMod
         }
 
         /// <summary>
-        /// Disables the default wing flap sound from vanilla; this is specifically to address issues with (currently) <see cref="CalamityMod.Items.Accessories.Wings.AureateBooster"/> and <see cref="CalamityMod.Items.Accessories.Wings.MOAB"/>.
+        /// Disables the default wing flap sound from vanilla; this is to stop custom wings playing this sound when they shouldnt
+        /// This must be called each update (eg, in the wings item UpdateAccessory method)
         /// </summary>
         /// <param name="player">The Player to disable the sound on</param>
-        public static void DisableDefaultWingFlapSound(this Player player)
+        public static void DisableWingFlapSound(this Player player)
         {
+            // vanilla plays a flap sound for all wings barring a few hardcoded exceptions
+            // the flapSound flag is used to see if the sound *has been* played, so we set it to true here to prevent it from playing 
             player.flapSound = true;
         }
 

--- a/Utilities/PlayerUtils.cs
+++ b/Utilities/PlayerUtils.cs
@@ -322,6 +322,16 @@ namespace CalamityMod
             }
             return ConditionMet;
         }
+
+        /// <summary>
+        /// Disables the default wing flap sound from vanilla; this is specifically to address issues with (currently) <see cref="CalamityMod.Items.Accessories.Wings.AureateBooster"/> and <see cref="CalamityMod.Items.Accessories.Wings.MOAB"/>.
+        /// </summary>
+        /// <param name="player">The Player to disable the sound on</param>
+        public static void DisableDefaultWingFlapSound(this Player player)
+        {
+            player.flapSound = true;
+        }
+
         #endregion
 
         #region Location and Biomes


### PR DESCRIPTION
Vanilla forces wings to play the Item32 wing flap sound for all wings barring a few hardcoded exceptions.

This change adds a new PlayerUtil method to disable the default Item32 wing flap sound

A method was created for semantics as setting the flag by itself is a bit ambiguous