### PR TITLE
Kill Chronomancer's Scythe projectiles on casters death

### DIFF
--- a/Projectiles/Magic/ChronoIcicleLarge.cs
+++ b/Projectiles/Magic/ChronoIcicleLarge.cs
@@ -30,6 +30,10 @@ namespace CalamityMod.Projectiles.Magic
 
         public override void AI()
         {
+            Player player = Main.player[Projectile.owner];
+            if (player is null || player.dead)
+                Projectile.Kill();
+                
             Projectile.ai[1]++;
             switch (Projectile.ai[0])
             {

--- a/Projectiles/Magic/ChronomancersScytheHoldout.cs
+++ b/Projectiles/Magic/ChronomancersScytheHoldout.cs
@@ -44,6 +44,10 @@ namespace CalamityMod.Projectiles.Magic
         {
             Owner.ChangeDir((int)Projectile.ai[2]);
 
+            Player player = Main.player[Projectile.owner];
+            if (player is null || player.dead)
+                Projectile.Kill();
+
             Projectile.velocity = Vector2.Zero;
 
             Projectile.rotation += (2 * MathHelper.Pi / 60) * Projectile.ai[2];


### PR DESCRIPTION
The Chronomancer's Scythe projectile AI didn't have checks to kill the projectiles if the player died. It functions similarly (enough) to The Final Dawn so I just copied how that handles its projectiles.

Theres definitely arguments to be had for how these projectiles should be disposed of. At the moment, this addresses the issue of the weapon finishes its animation even after the player dies.