### PR TITLE
Fix: Remove ManagedTargets reinitialization in OnModLoad

### DIFF
--- a/Graphics/RenderTargetManager.cs
+++ b/Graphics/RenderTargetManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ModLoader;
 
@@ -11,7 +10,7 @@ namespace CalamityMod.Graphics
     /// </summary>
     public class RenderTargetManager : ModSystem
     {
-        internal static List<ManagedRenderTarget> ManagedTargets = new();
+        internal static List<ManagedRenderTarget> ManagedTargets = [];
 
         public delegate void RenderTargetUpdateDelegate();
 
@@ -55,7 +54,6 @@ namespace CalamityMod.Graphics
 
         public override void OnModLoad()
         {
-            ManagedTargets = new();
             Main.OnPreDraw += HandleTargetUpdateLoop;
             Main.OnResolutionChanged += ResetTargetSizes;
         }


### PR DESCRIPTION
Removed the reinitialization of ManagedTargets in ModLoad because it removed some of the rendertargets on the mod that loaded before OnModLoad this makes that the pixelated primitives RTs are now properly resized when changing the game resolution ex sylvstaff primitives looking weird when changing game resolution