### PR TITLE
Moved the FirstStage brothers check before other logic to prevent an unfair frame where scal shouldnt be able to attack

### DIFF
--- a/NPCs/SupremeCalamitas/SupremeCalamitas.cs
+++ b/NPCs/SupremeCalamitas/SupremeCalamitas.cs
@@ -2051,6 +2051,18 @@ namespace CalamityMod.NPCs.SupremeCalamitas
             #region FirstStage
             if (NPC.ai[0] == 0f)
             {
+
+                // Previously the 0.4% health threshold transition
+                if (lifeRatio <= 0.45f && hasSummonedBrothers && (permafrost ? NPC.AnyNPCs(ModContent.NPCType<DevourerofGodsHead>()) : (NPC.AnyNPCs(ModContent.NPCType<SupremeCataclysm>()) || NPC.AnyNPCs(ModContent.NPCType<SupremeCatastrophe>()))) == false)
+                {
+                    NPC.ai[0] = 1f;
+                    NPC.ai[1] = 0f;
+                    NPC.ai[2] = 0f;
+                    NPC.ai[3] = 0f;
+                    NPC.TargetClosest();
+                    NPC.netUpdate = true;
+                }
+
                 if (wormAlive)
                 {
                     NPC.dontTakeDamage = true;
@@ -2539,16 +2551,6 @@ namespace CalamityMod.NPCs.SupremeCalamitas
                     }
                 }
 
-                // Previously the 0.4% health threshold transition
-                if (lifeRatio <= 0.45f && hasSummonedBrothers && (permafrost ? NPC.AnyNPCs(ModContent.NPCType<DevourerofGodsHead>()) : (NPC.AnyNPCs(ModContent.NPCType<SupremeCataclysm>()) || NPC.AnyNPCs(ModContent.NPCType<SupremeCatastrophe>()))) == false)
-                {
-                    NPC.ai[0] = 1f;
-                    NPC.ai[1] = 0f;
-                    NPC.ai[2] = 0f;
-                    NPC.ai[3] = 0f;
-                    NPC.TargetClosest();
-                    NPC.netUpdate = true;
-                }
             }
             #endregion
             #region Transition


### PR DESCRIPTION
The check to prevent Scal from doing anything while changing phase after the defeat of brothers was placed in a faulty position giving one possible frame before brothers phase began where NPC.ai[3] could have a specific value that allowed it to run in the time between realizing both brothers died and disabling Scal's attacks for the phase transition