### PR TITLE
Add OnKill to Primordial Wyrm to correctly set its downed flag

### DIFF
--- a/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
+++ b/NPCs/PrimordialWyrm/PrimordialWyrmHead.cs
@@ -1452,6 +1452,15 @@ namespace CalamityMod.NPCs.PrimordialWyrm
             potionType = ModContent.ItemType<OmegaHealingPotion>();
         }
 
+        public override void OnKill()
+        {
+            CalamityGlobalNPC.SetNewBossJustDowned(NPC);
+
+            // Mark Primordial Wyrm as dead
+            DownedBossSystem.downedPrimordialWyrm = true;
+            CalamityNetcode.SyncWorld();
+        }
+        
         public override void ModifyNPCLoot(NPCLoot npcLoot)
         {
             npcLoot.Add(ModContent.ItemType<EidolicWail>());


### PR DESCRIPTION
While working with Calamity and using the [`GetBossDowned`](https://github.com/CalamityTeam/CalamityModPublic/blob/1.4.4/ModSupport/ModCalls.cs#L29) function via `Mod.Call` in my own mod, I investigated Calamity’s source code and discovered that the variable [`DownedBossSystem.downedPrimordialWyrm`](https://github.com/CalamityTeam/CalamityModPublic/blob/1.4.4/Systems/DownedBossSystem.cs#L373) is never set to `true`. 
Unlike other bosses, the flag responsible for marking the first kill was not being updated.

I added the implementation of this in the `OnKill` hook, similar to all other bosses in Calamity.
After testing, everything now works correctly and the [`DownedBossSystem.downedPrimordialWyrm`](https://github.com/CalamityTeam/CalamityModPublic/blob/1.4.4/Systems/DownedBossSystem.cs#L373) flag properly reflects its intended value.

Maybe I’m missing something, but it seems to me that this is a bug or something similar.