### PR TITLE
Fix: AnySolidTileInSelection always returns false due to inverted logic

### DIFF
--- a/Utilities/TileUtils.cs
+++ b/Utilities/TileUtils.cs
@@ -237,7 +237,7 @@ namespace CalamityMod
             {
                 for (int j = y; j != y + height; j += Math.Sign(height))
                 {
-                    if (WorldGen.InWorld(i, j))
+                    if (!WorldGen.InWorld(i, j))
                         continue;
 
                     if (WorldGen.SolidTile(Framing.GetTileSafely(i, j)))


### PR DESCRIPTION
AnySolidTileInSelection was incorrectly skipping all in bounds tiles due to an inverted conditional check:

```cs
if (WorldGen.InWorld(i, j))
    continue;
```

This caused the rest of the function to only ever check out of bounds tiles which can never be solid, resulting in this method always returning false.

This condition has been inverted to correctly check tiles that are in bounds and skip those that are out of bounds:

```cs
if (!WorldGen.InWorld(i, j))
    continue;
```