### PR TITLE
Fix: BarLoot has never worked in MudPlanet and GiantHive chests

### DIFF
--- a/World/GiantHive.cs
+++ b/World/GiantHive.cs
@@ -603,7 +603,7 @@ namespace CalamityMod.World
             if (random.Next(3) <= 1)
             {
                 chest.item[index].SetDefaults(random.Next(BarLootHoney));
-                chest.item[index].SetDefaults(random.Next(7, 15));
+                chest.item[index++].stack = random.Next(7, 15);
             }
             else
             {

--- a/World/Planets/MudPlanet.cs
+++ b/World/Planets/MudPlanet.cs
@@ -228,7 +228,7 @@ namespace CalamityMod.World.Planets
             if (_random.Next(3) <= 1)
             {
                 chest.item[index].SetDefaults(_random.Next(BarLoot));
-                chest.item[index].SetDefaults(_random.Next(7, 15));
+                chest.item[index++].stack = _random.Next(7, 15);
             }
             else
             {


### PR DESCRIPTION
This PR fixes two longstanding bugs in the `FillChest` methods for `GiantHive` and `MudPlanet`. As a result of these issues, `BarLoot` has never been correctly generated in chests since the features were first introduced.

The bugs trace back to the initial implementation of these features:
* **MudPlanet**: Introduced in 32af77f (initial upload 7 years ago, unsure how long it has existed in the private/older versions).
~~* **GiantHive**: Introduced in 6d1c2b3  (`GiantHive` initial commit, `FillChest` copied from `MudPlanet`).~~
* **GiantHive**: Introduced in 2d8944f (initial commit of `FillHoneyChest` in `MiscWorldgenRoutines` which was then added directly to `GiantHive` in 6d1c2b3).

The chest generation logic suffered from two main issues:

**1. Item type overwritten by stack count**
The code attempts to set the type and then its stack count using two consecutive calls to `SetDefaults()`:
```cs
chest.item[index].SetDefaults(random.Next(BarLoot));
chest.item[index].SetDefaults(random.Next(7, 15));
```
The second call doesn't set the stack count, it overwrites the type with `(7-14)`. This results in the chest containing an incorrect vanilla item (`IronHammer`, `Torch`, `Wood`, `IronAxe`, `IronOre`, `CopperOre`, `GoldOreSilverOre`) instead of the intended `BarLoot` item.


**2. Incorrect chest item slot/index**
The index was never incremented after the type/stack was set. This caused the item to be overwritten by the next item as the index was reused.

These two bugs masked each other. The first bug placed the wrong item and the second bug overwrote the wrong item with another valid item. This hid the issue for 7+ years.

The fix is to:
1. Replace the second `SetDefaults()` call with an assignment to `.stack` to correctly set the stack count.
2. Increment the index after setting the stack to avoid overwriting the `BarLoot` with a different item.