### PR TITLE
FlightBar Label Icon CalamityMod/DrewsWings -> CalamityMod/SkylineWings

### DIFF
--- a/Localization/en-US/Mods.CalamityMod.Configs.hjson
+++ b/Localization/en-US/Mods.CalamityMod.Configs.hjson
@@ -187,7 +187,7 @@ CalamityConfig: {
 	}
 
 	FlightBar: {
-		Label: "[i:CalamityMod/DrewsWings] Display Flight Bar"
+		Label: "[i:CalamityMod/SkylineWings] Display Flight Bar"
 		Tooltip:
 			'''
 			Enables the Flight Bar UI, which shows the player's remaining wing flight time.


### PR DESCRIPTION
```
The mod config menu was still using a reference to DrewsWings
for the Flight Bar option icon, this changes it to Skyline Wings instead.
```

Before:
<img width="957" height="169" alt="image" src="https://github.com/user-attachments/assets/4ee5bea4-da07-4f04-9fa1-5cd3b2773f1d" />

After:
<img width="121" height="126" alt="image" src="https://github.com/user-attachments/assets/926cb465-167d-4ea6-b2c8-c95468e455e5" />
