### PR TITLE
Avoiding invalid casting in case of different ModWaterStyle.

### DIFF
--- a/Systems/CalamityModWaterStyle.cs
+++ b/Systems/CalamityModWaterStyle.cs
@@ -38,19 +38,27 @@ namespace CalamityMod.Systems
     {
         internal static void ModifyLightSetup(int i, int j, int type, ref float r, ref float g, ref float b)
         {
-            CalamityModWaterStyle styles = (CalamityModWaterStyle)LoaderManager.Get<WaterStylesLoader>().Get(type);
-            if (styles != null)
+            ModWaterStyle waterStyle = LoaderManager.Get<WaterStylesLoader>().Get(type);
+            if(waterStyle is CalamityModWaterStyle)
             {
-                styles?.ModifyLight(i, j, ref r, ref g, ref b);
+                CalamityModWaterStyle styles = (CalamityModWaterStyle)waterStyle;
+                if (styles != null)
+                {
+                    styles?.ModifyLight(i, j, ref r, ref g, ref b);
+                }
             }
         }
 
         internal static void DrawColorSetup(int x, int y, int type, ref VertexColors liquidColor, bool isSlope = false)
         {
-            CalamityModWaterStyle styles = (CalamityModWaterStyle)LoaderManager.Get<WaterStylesLoader>().Get(type);
-            if (styles != null)
+            ModWaterStyle waterStyle = LoaderManager.Get<WaterStylesLoader>().Get(type);
+            if(waterStyle is CalamityModWaterStyle)
             {
-                styles?.DrawColor(x, y, ref liquidColor, isSlope);
+                CalamityModWaterStyle styles = (CalamityModWaterStyle)waterStyle;
+                if (styles != null)
+                {
+                    styles?.DrawColor(x, y, ref liquidColor, isSlope);
+                }
             }
         }
     }


### PR DESCRIPTION
was having an issue with the new liquid changes when it was trying to cast another mods subclass of ModWaterType into CalamityModWaterStyle. Tried a try catch but that ended up messing still causing issues so just circumventing it by checking if we can cast in the first place!

First time doing a terraria mod fix so please let me know if I did the PR and all correctly :)

Here's the error it was throwing:
```
System.InvalidCastException: Unable to cast object of type 'WombatQOL.Biomes.Waters.VileWater' to type 'CalamityMod.Systems.CalamityModWaterStyle'.
at CalamityMod.Systems.CalamityWaterLoader.ModifyLightSetup(Int32 i, Int32 j, Int32 type, Single& r, Single& g, Single& b) in CalamityModWaterStyle.cs:line 41
```