### PR TITLE
Updates to the Sulphurous bg and sky

### DIFF
--- a/Backgrounds/SulphurSeaSurfaceBGStyle.cs
+++ b/Backgrounds/SulphurSeaSurfaceBGStyle.cs
@@ -1,15 +1,14 @@
-﻿using Terraria.ModLoader;
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.Graphics.Effects;
+using Terraria.ModLoader;
 
 namespace CalamityMod.Backgrounds
 {
     public class SulphurSeaSurfaceBGStyle : ModSurfaceBackgroundStyle
     {
-        public override int ChooseCloseTexture(ref float scale, ref double parallax, ref float a, ref float b)
-        {
-            b -= 100f;
-            return BackgroundTextureLoader.GetBackgroundSlot("CalamityMod/Backgrounds/BlankPixel");
-        }
-
         public override void ModifyFarFades(float[] fades, float transitionSpeed)
         {
             //This just fades in the background and fades out other backgrounds.
@@ -32,6 +31,68 @@ namespace CalamityMod.Backgrounds
                     }
                 }
             }
+        }
+
+        public override int ChooseCloseTexture(ref float scale, ref double parallax, ref float a, ref float b)
+        {
+            return BackgroundTextureLoader.GetBackgroundSlot("CalamityMod/Backgrounds/SulphurSeaSurfaceClose");
+        }
+
+        public override bool PreDrawCloseBackground(SpriteBatch spriteBatch) //Taken from astral bg so the sulphur sea bg doesn't overlap other backgrounds
+        {
+            float screenOff = (float)AstralSurfaceBGStyle.screenOffField.GetValue(Main.instance);
+            float scAdj = (float)AstralSurfaceBGStyle.scAdjField.GetValue(Main.instance);
+            Color ColorOfSurfaceBackgroundsModified = (Color)AstralSurfaceBGStyle.COSBMAplhaField.GetValue(null);
+            bool canBGDraw = false;
+            if ((!Main.remixWorld || (Main.gameMenu && !WorldGen.remixWorldGen)) && (!WorldGen.remixWorldGen || !WorldGen.drunkWorldGen))
+                canBGDraw = true;
+            if (Main.mapFullscreen)
+                canBGDraw = false;
+            int offset = 30;
+            if (Main.gameMenu)
+                offset = 0;
+            if (WorldGen.drunkWorldGen)
+                offset = -180;
+            float surfacePosition = (float)Main.worldSurface;
+            if (surfacePosition == 0f)
+                surfacePosition = 1f;
+            float screenPosition = Main.screenPosition.Y + (float)(Main.screenHeight / 2) - 600f;
+            double backgroundTopMagicNumber = (0f - screenPosition + screenOff / 2f) / (surfacePosition * 16f);
+            float bgGlobalScaleMultiplier = 2f;
+            int pushBGTopHack;
+            int offset2 = -180;
+            int menuOffset = 0;
+            if (Main.gameMenu)
+            {
+                menuOffset -= offset2;
+            }
+            pushBGTopHack = menuOffset;
+            pushBGTopHack += offset;
+            pushBGTopHack += offset2; //Offsets to the background placement
+            if (canBGDraw) //If the background can draw (player is not in a remix world or is not in a map).  This can probably be removed since backgrounds already go through these checks
+            {
+                var bgScale = 1.25f; //Scale of the furthest of the closest background layers
+                var bgParallax = 0.4; //The parallax of the background layer
+                var bgTopY = (int)(backgroundTopMagicNumber * 1800.0 + 1500.0) + (int)scAdj + pushBGTopHack; //the Y position of the background
+                bgScale *= bgGlobalScaleMultiplier; //Scale of the background
+                var bgWidthScaled = (int)((float)CalamityMod.SulphurSeaSurface.Width * bgScale); //The Width of the bg texture scaled to the correct size
+                SkyManager.Instance.DrawToDepth(Main.spriteBatch, 1.2f / (float)bgParallax);
+                var bgStartX = (int)(0.0 - Math.IEEERemainder((double)Main.screenPosition.X * bgParallax, bgWidthScaled) - (double)(bgWidthScaled / 2)); //The starting position of the background layer
+                if (Main.gameMenu)
+                    bgTopY = 320 + pushBGTopHack; //increases the height in the main menu
+
+                var bgLoops = Main.screenWidth / bgWidthScaled + 2;
+                if ((double)Main.screenPosition.Y < Main.worldSurface * 16.0 + 16.0)
+                {
+                    for (int i = 0; i < bgLoops; i++)
+                    {
+                        //Draw the texture and its glowmask to each loop of the texture
+                        Main.spriteBatch.Draw(CalamityMod.SulphurSeaSurface, new Vector2(bgStartX + bgWidthScaled * i, bgTopY + 400), new Rectangle(0, 0, CalamityMod.SulphurSeaSurface.Width, CalamityMod.SulphurSeaSurface.Height), ColorOfSurfaceBackgroundsModified, 0f, default(Vector2), bgScale, SpriteEffects.None, 0f);
+                        Main.spriteBatch.Draw(CalamityMod.SulphurSeaSkyFront, new Vector2(bgStartX + bgWidthScaled * i, bgTopY + 400), new Rectangle(0, 0, CalamityMod.SulphurSeaSkyFront.Width, CalamityMod.SulphurSeaSkyFront.Height), new Color(Color.LightSeaGreen.R, Color.LightSeaGreen.G, Color.LightSeaGreen.B, ColorOfSurfaceBackgroundsModified.A) * 0.5f, 0f, default(Vector2), bgScale, SpriteEffects.None, 0f);
+                    }
+                }
+            }
+            return false; //Stop the drawing of the base close background texture (note: does NOT stop the drawing of the Middle and Far textures because tmodloader is slight stupid :blushing:)
         }
     }
 }

--- a/Skies/SulphurSeaSky.cs
+++ b/Skies/SulphurSeaSky.cs
@@ -13,11 +13,6 @@ namespace CalamityMod.Skies
         private bool skyActive;
         private float opacity;
 
-        private const float ScreenParralaxMultiplier = 0.4f;
-
-        // Vanila scales backgrounds to 250% size. Depending on what you might want to do you can change this if you wanted to make a non scaled bg.
-        private const float Scale = 2.5f;
-
         public override void Deactivate(params object[] args)
         {
             skyActive = Main.LocalPlayer.Calamity().ZoneSulphur;
@@ -42,66 +37,6 @@ namespace CalamityMod.Skies
         {
             if (maxDepth >= 4f && minDepth < 4f)
                 spriteBatch.Draw(CalamityMod.SulphurSeaSky, new Rectangle(0, (int)(-Main.screenPosition.Y / 6f) + 1300, Main.screenWidth, Main.screenHeight), Color.Lerp(Main.ColorOfTheSkies, Color.LightSeaGreen, 0.33f) * 0.2f * opacity);
-
-            // Small worlds, default draw height
-            int sulphurSeaHeight = (World.SulphurousSea.YStart + (int)Main.worldSurface) / 2;
-
-            // Medium worlds
-            if (Main.maxTilesX >= 6400 && Main.maxTilesX < 8400)
-                sulphurSeaHeight = (World.SulphurousSea.YStart + (int)Main.worldSurface) / 5;
-
-            // Large worlds (and anything bigger)
-            if (Main.maxTilesX >= 8400)
-                sulphurSeaHeight = (World.SulphurousSea.YStart + (int)Main.worldSurface) / 140;
-
-            // Explantion on how to use this BG code for skies.
-            // This changes the speed of the parralax, the closer the layer to the player the faster it should be.
-            if (maxDepth >= 1f && minDepth < 1f)
-            {
-                Texture2D texture = CalamityMod.SulphurSeaSkyFront;
-
-                // Keep in mind that y paralex should always be half of x's or it will feel odd compared to how terraria does it.
-                // Keep in mind when you change screen parralax it affects the y offset for the bg in the world.
-                int x = (int)(Main.screenPosition.X * ScreenParralaxMultiplier);
-                x %= (int)(texture.Width * Scale);
-                int y = (int)(Main.screenPosition.Y * 0.5f * ScreenParralaxMultiplier);
-
-                // Y offset to align with whatever position you want it in the world (is affected by screenParralaxMultiplier as stated before).
-                y -= 1800;
-
-                float screenWidth = Main.screenWidth / 2f;
-                float screenHeight = Main.screenHeight / 2f;
-                Vector2 position = texture.Size() / 2f * Scale;
-                Color color = Color.LightSeaGreen * 0.5f * opacity;
-
-                // This loops the BG horizontally.
-                for (int k = -1; k <= 1; k++)
-                {
-                    var pos = new Vector2(screenWidth - x + texture.Width * k * Scale, screenHeight - y);
-                    spriteBatch.Draw(texture, pos - position, null, color, 0f, new Vector2(0f, (float)sulphurSeaHeight), Scale, SpriteEffects.None, 0f);
-                }
-            }
-
-            if (maxDepth >= 3f && minDepth < 3f)
-            {
-                Texture2D texture = CalamityMod.SulphurSeaSurface;
-
-                int x = (int)(Main.screenPosition.X * ScreenParralaxMultiplier);
-                x %= (int)(texture.Width * Scale);
-                int y = (int)(Main.screenPosition.Y * 0.5f * ScreenParralaxMultiplier);
-                y -= 1800; // 1000
-
-                float screenWidth = Main.screenWidth / 2f;
-                float screenHeight = Main.screenHeight / 2f;
-                Vector2 position = texture.Size() / 2f * Scale;
-                Color color = Main.ColorOfTheSkies * opacity;
-
-                for (int k = -1; k <= 1; k++)
-                {
-                    var pos = new Vector2(screenWidth - x + texture.Width * k * Scale, screenHeight - y);
-                    spriteBatch.Draw(texture, pos - position, null, color, 0f, new Vector2(0f, (float)sulphurSeaHeight), Scale, SpriteEffects.None, 0f);
-                }
-            }
         }
 
         public override void Update(GameTime gameTime)


### PR DESCRIPTION
Updates to the Sulphureous Sky and Background to better transition between Sulphur sea and other biomes

Currently the Sulphur sea is inconsistent when transitioning, using CustomSky to render both the sky and the background instead of ModSurfaceBackground. This PR fixes it, using similar code to the Astral Background that I wrote a year and a bit ago. It supports all features that the old background could while transitioning much better, no longer lingering and having both the Sulphur sea background and other backgrounds showing at the same time

Transitioning between the sulphur sea current:
<img width="2559" height="1407" alt="Screenshot 2025-11-28 171920" src="https://github.com/user-attachments/assets/35e3551c-e6c6-42e3-9f20-dac4138ecd28" />
Transitioning between the sulphur sea new:
<img width="2558" height="1413" alt="image" src="https://github.com/user-attachments/assets/1b7288b0-4cb8-4436-8bf0-335d21054dc1" />
Sulphur sea background + sky current:
<img width="2556" height="1414" alt="Screenshot 2025-11-28 172239" src="https://github.com/user-attachments/assets/46f90668-ed8a-4984-a0c3-88cdfe57a4dc" />
Sulphur sea background + sky new:
<img width="2559" height="1415" alt="Screenshot 2025-11-28 172258" src="https://github.com/user-attachments/assets/e231f5e1-97fe-4db4-9baf-fec0fdff2a70" />
