### PR TITLE
Enable custom font loading regardless of operating system

### DIFF
--- a/UI/BossHealthBarManager.cs
+++ b/UI/BossHealthBarManager.cs
@@ -103,11 +103,7 @@ namespace CalamityMod.UI
                 BossComboHPBar = Request<Texture2D>("CalamityMod/UI/MiscTextures/BossHPComboBar", AssetRequestMode.ImmediateLoad).Value;
                 BossSeperatorBar = Request<Texture2D>("CalamityMod/UI/MiscTextures/BossHPSeperatorBar", AssetRequestMode.ImmediateLoad).Value;
 
-                PlatformID id = Environment.OSVersion.Platform;
-                if (id == PlatformID.Win32NT)
-                    HPBarFont = Request<DynamicSpriteFont>("CalamityMod/Fonts/HPBarFont", AssetRequestMode.ImmediateLoad).Value;
-                else
-                    HPBarFont = FontAssets.MouseText.Value;
+                HPBarFont = Request<DynamicSpriteFont>("CalamityMod/Fonts/HPBarFont", AssetRequestMode.ImmediateLoad).Value;
             }
 
             OneToMany = new Dictionary<int, int[]>();

--- a/UI/DraedonSummoning/CodebreakerUI.Communication.cs
+++ b/UI/DraedonSummoning/CodebreakerUI.Communication.cs
@@ -260,11 +260,8 @@ namespace CalamityMod.UI.DraedonSummoning
         {
             if (Main.dedServ)
                 return;
-
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                DialogFont = CalamityMod.Instance.Assets.Request<DynamicSpriteFont>("Fonts/CodebreakerDialog", AssetRequestMode.ImmediateLoad).Value;
-            else
-                DialogFont = FontAssets.MouseText.Value;
+            
+            DialogFont = CalamityMod.Instance.Assets.Request<DynamicSpriteFont>("Fonts/CodebreakerDialog", AssetRequestMode.ImmediateLoad).Value;
         }
 
         public static void DisplayCommunicationPanel()


### PR DESCRIPTION
Enable custom font loading regardless of operating system

This applies to the custom fonts used in the Boss Health Bar and the font Draedon uses for communication in the Codebreaker UI
I made this patch a while ago and have been testing it for a while. I know Calamity disables custom font loading on Linux and Mac OS for a reason, which was tMod being unreliable with loading fonts on these platforms several years ago.

However, its been years since then and I did a 68+ hour playthrough with this change (with Infernum as well) on a variety of Linux distros and the Steam Deck, and ran into zero issues in terms of errors or loading issues.
I can confidently say that whatever bug caused the font loading issues years ago has been fixed on the tModLoader side, and that it should be safe to remove this check.

I've also noticed that when using the default Terraria font, Draedon's communication UI cuts off the text earlier than it should, so always having the fonts load will improve readability when not playing on Windows.