### PR TITLE
Fixed biome lava mod crashing when enabled alongside calamity

### DIFF
--- a/ModSupport/WeakReferenceSupport.cs
+++ b/ModSupport/WeakReferenceSupport.cs
@@ -180,9 +180,13 @@ namespace CalamityMod
             // { "Xeroc", 26f },
         };
 
-        public override void PostSetupContent()
+        public override void Load()
         {
             LavaStyleToBiomeLava();
+        }
+
+        public override void PostSetupContent()
+        {
             BossChecklistSupport();
             FargosSupport();
             DialogueTweakSupport();
@@ -214,7 +218,7 @@ namespace CalamityMod
                     Func<int, int, float, float, float, Vector3> ModifyLightFunc = ModifyLight;
                     Func<bool> IsLavaActive = lavaStyle.IsLavaActive;
                     Func<bool> lavafallGlowmask = lavaStyle.LavafallGlowmask;
-                    Func<Player, NPC, int, Action> InflictDebuffFunc = InflictDebuff;
+                    Action<Player, NPC, int> InflictDebuffFunc = InflictDebuff;
                     Func<bool> yes = InflictsOnFire;
 
                     Vector3 ModifyLight(int x, int y, float r, float g, float b)
@@ -223,13 +227,12 @@ namespace CalamityMod
                         return new Vector3(r, g, b);
                     }
 
-                    Action InflictDebuff(Player player, NPC npc, int onfireDuration)
+                    void InflictDebuff(Player player, NPC npc, int onfireDuration)
                     {
                         if (player != null && npc == null)
                         {
                             lavaStyle.InflictDebuff(player, onfireDuration);
                         }
-                        return null;
                     }
 
                     bool InflictsOnFire()


### PR DESCRIPTION
Before the brainstorm update, mod calls were pretty messy and thankfully since then they have been cleaned up.

During this process of cleaning, biome lava's mod calls were moved from Load to PostSetupContent which causes biome lava to fail to register the styles as it's too late into mod loading to add new content.

To avoid this, WeakReferenceSupport now has a load override (which is loaded after ExternalMods due to tmodloader loading sorting) which is used to add all calamity lava styles into biome lava

(I have also removed the really awkward use of an Action as the return for a Func (This was because I was a dumbass and didn't connect the dots that Action returned void while Func returned the last parameter, thank you past me))