### PR TITLE
Fix: Memory leak in VengefulSunSpiritMinion.PreDraw() causing GPU/CPU resource exhaustion

### DIFF
--- a/Projectiles/Summon/VengefulSunSpiritMinion.cs
+++ b/Projectiles/Summon/VengefulSunSpiritMinion.cs
@@ -147,7 +147,6 @@ namespace CalamityMod.Projectiles.Summon
         public static Asset<Texture2D> circle;
         public override bool PreDraw(ref Color lightColor)
         {
-            AllWhiteVersion = null;
             var spTex = TextureAssets.Projectile[Type].Value;
             var whiteTex = GetWhiteTex();
             var ciTex = CalamityUtils.GetTextureEfficient(ref circle, "CalamityMod/ExtraTextures/GreyscaleOpenCircleButBigger").Value;


### PR DESCRIPTION
## Bug Description
`VengefulSunSpiritMinion.PreDraw()` causes memory leak by recreating `Texture2D` every frame.

### Root Cause
Line 150 in `VengefulSunSpiritMinion.cs`:
```csharp
AllWhiteVersion = null;  // Forces texture recreation every frame
```
This nullifies the cached texture, causing GetWhiteTex() to execute new Texture2D() every single frame without disposing the previous instance.

## Evidence
A 200x multiplier was applied locally to compress the timeline.
* GPU Memory Growth: <img width="370" height="280" alt="屏幕截图 2026-02-18 184306" src="https://github.com/user-attachments/assets/1cba5f12-51ff-4538-80bf-439b0b02ba42" />

* Managed Heap:  [VS profiler](https://drive.google.com/file/d/1ayjFFt2AwM0ZQfuYXc0TV-SySPlhVKy_/view?usp=sharing)  showing WeakReference explosion.    


## Fix
Remove the erroneous null assignment to preserve the cached texture.

