### PR TITLE
Fix UI overlapping and scaling for CalamitasEnchantUI & InvasionProgressUIManager

### DIFF
--- a/Systems/UIManagementSystem.cs
+++ b/Systems/UIManagementSystem.cs
@@ -174,7 +174,7 @@ namespace CalamityMod.Systems
                 {
                     InvasionProgressUIManager.UpdateAndDraw(Main.spriteBatch);
                     return true;
-                }, InterfaceScaleType.None));
+                }, InterfaceScaleType.UI));
             }
         }
     }

--- a/UI/CalamitasEnchantments/CalamitasEnchantUI.cs
+++ b/UI/CalamitasEnchantments/CalamitasEnchantUI.cs
@@ -24,7 +24,7 @@ namespace CalamityMod.UI.CalamitasEnchants
 
         public static bool CurrentlyViewing = false;
 
-        public static readonly Vector2 ReforgeUITopLeft = new Vector2(68f, 320f);
+        public static Vector2 ReforgeUITopLeft => new Vector2(68f, 320f) * Main.UIScale;
         public static readonly float ResolutionRatio = Main.screenHeight / 1440f;
 
         public static readonly SoundStyle EnchSound = new("CalamityMod/Sounds/Custom/WeaponEnchant");


### PR DESCRIPTION
This PR addresses UI overlapping and scaling issues that occur on high UI Scale

Before and after fix:

<img width="2281" height="891" alt="image" src="https://github.com/user-attachments/assets/5831816a-5076-4a49-ac6c-413541a77b24" />

<img width="1042" height="291" alt="image" src="https://github.com/user-attachments/assets/34f3e81e-c839-4abe-876c-bf3313715ca4" />

