### PR TITLE
Fix: Prevent NullReferenceException in ModifyTooltips when iterating tooltips

### DIFF
--- a/Items/CalamityGlobalItemTooltip.cs
+++ b/Items/CalamityGlobalItemTooltip.cs
@@ -113,7 +113,7 @@ namespace CalamityMod.Items
             int standardTooltipCount = 0;
             for (int i = 0; i < tooltips.Count; i++)
             {
-                if (tooltips[i].Name.StartsWith("Tooltip"))
+                if (tooltips[i]?.Name?.StartsWith("Tooltip") == true)
                 {
                     if (firstTooltipIndex == -1)
                         firstTooltipIndex = i;


### PR DESCRIPTION
This PR fixes a critical issue where the game would freeze or throw a System.NullReferenceException when using the search bar in the Creative Inventory (Journey Mode)
The bug isn't reproducible on regular seeds
It was discovered and is reproducible on get fixed boi

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CalamityMod.Items.CalamityGlobalItem.ModifyTooltips(Item item, List`1 tooltips) in CalamityMod\Items\CalamityGlobalItem.cs:line 116
   ...
   at Terraria.GameContent.UI.Elements.UICreativeInfiniteItemsDisplay.UpdateContents()
```


https://github.com/user-attachments/assets/f8258c8a-d998-487f-afa6-2fabd9a0c763

