### PR TITLE
Fixed Sulphuric Sea water lighting not changing based on world height

### DIFF
--- a/Waters/SulphuricWater.cs
+++ b/Waters/SulphuricWater.cs
@@ -59,9 +59,9 @@ namespace CalamityMod.Waters
             {
                 if (Main.dayTime && !Main.raining)
                 {
-                    float brightness = MathHelper.Clamp(0.2f - (j / 680), 0f, 0.2f);
-                    if (j > 580)
-                        brightness *= 1f - (j - 580) / 100f;
+                    float brightness = MathHelper.Clamp(0.2f - (j / ((int)Main.worldSurface + 120)), 0f, 0.2f);
+                    if (j > (int)Main.worldSurface + 20)
+                        brightness *= 1f - (j - ((int)Main.worldSurface + 20)) / 100f;
 
                     float time = Main.GameUpdateCount;
                     float waveScale1 = time * 0.014f;
@@ -83,9 +83,9 @@ namespace CalamityMod.Waters
 
                 if (!Main.dayTime && !Main.raining)
                 {
-                    float brightness = MathHelper.Clamp(0.17f - (j / 680), 0f, 0.17f);
-                    if (j > 580)
-                        brightness *= 1f - (j - 580) / 100f;
+                    float brightness = MathHelper.Clamp(0.17f - (j / ((int)Main.worldSurface + 120)), 0f, 0.17f);
+                    if (j > ((int)Main.worldSurface + 20))
+                        brightness *= 1f - (j - ((int)Main.worldSurface + 20)) / 100f;
 
                     float waveScale1 = Main.GameUpdateCount * 0.014f;
                     float waveScale2 = Main.GameUpdateCount * 0.1f;
@@ -106,9 +106,9 @@ namespace CalamityMod.Waters
 
                 if (Main.raining)
                 {
-                    float brightness = MathHelper.Clamp(1f - (j / 680), 0f, 1f);
-                    if (j > 580)
-                        brightness *= 1f - (j - 580) / 100f;
+                    float brightness = MathHelper.Clamp(1f - (j / ((int)Main.worldSurface + 120)), 0f, 1f);
+                    if (j > ((int)Main.worldSurface + 20))
+                        brightness *= 1f - (j - ((int)Main.worldSurface + 20)) / 100f;
 
                     outputColor = Vector3.Lerp(outputColor, Color.LightSeaGreen.ToVector3(), 0.41f);
                     outputColor *= brightness;


### PR DESCRIPTION
Currently in Calamity, sulphuric water has a hardcoded height for when the lighting stops to prevent the light from reaching too far underground. These values are at the hardcoded heights of 680 and 580, these values being fine normally with large world surfaces being 560 and medium world surfaces being 584.

In custom created or sized worlds this is a major issue, as world height varies much differently than the vanilla medium and large world sizes supported by Calamity, causing the lighting to end much earlier than normal. Due to the lighting ending much sooner before the underground layer, this causes visual tearing and other rendering issues where some of the background is visible even when in complete darkness.

This PR fixes the sluphuric water lighting by dynamically changing where the light starts to dim from a hardcoded value to using Main.worldSurface (and adding either 120 or 20 where relevant). Large worlds won't have much of a change from this PR but medium worlds will have the liquid dim start 24 tiles deeper than normal.

Custom world (using the remnants mod) without the fix
<img width="2558" height="1409" alt="image" src="https://github.com/user-attachments/assets/7abb2fdd-71f4-414c-8467-35737fcc419f" />


Custom world (using the remnants mod) with the fix
<img width="2559" height="1409" alt="image" src="https://github.com/user-attachments/assets/fcd93bdb-19c7-443e-82e1-7e4a5a7b4a60" />