### PR TITLE
Fix the bug that every first shot of The Sevens Striker get Bust

### DIFF
--- a/Items/Weapons/Ranged/TheSevensStriker.cs
+++ b/Items/Weapons/Ranged/TheSevensStriker.cs
@@ -60,7 +60,7 @@ namespace CalamityMod.Items.Weapons.Ranged
         public override bool CanUseItem(Player player) => player.ownedProjectileCounts[Item.shoot] <= 0;
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {
-            Projectile holdout = Projectile.NewProjectileDirect(source, player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<SevensStrikerHoldout>(), damage, knockback, player.whoAmI);
+            Projectile holdout = Projectile.NewProjectileDirect(source, player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<SevensStrikerHoldout>(), damage, knockback, player.whoAmI, type, 0f);
 
             // We set the rotation to the direction to the mouse so the first frame doesn't appear bugged out.
             holdout.velocity = (player.Calamity().mouseWorld - player.MountedCenter).SafeNormalize(Vector2.Zero);


### PR DESCRIPTION
My friend told me that when he used The Sevens Striker, it would get bust even if a plantium coin was consumed. After testing, I found that every first shot of The Sevens Striker was bound to get bust, no matter what kind of coin was consumed. If the player holds down the mouse, all shots fired after the first shot will behave normally.

I compared the previous version and the current version of TheSevensStriker.cs.
Then I noticed that the projectile was created like this in the previous version:

Projectile.NewProjectile(source, position, velocity, ModContent.ProjectileType<SevensStrikerHoldout>(), damage, knockback, player.whoAmI, type, 0f);

By contrast, the current version uses this to create the projectile:

Projectile.NewProjectileDirect(source, player.MountedCenter, Vector2.Zero, ModContent.ProjectileType<SevensStrikerHoldout>(), damage, knockback, player.whoAmI);

The current code omits the two parameters ' type ' and ' 0f '.

I tried adding these two arguments back and rebuilt the mod. After that, every first shot of The Sevens Striker worked correctly, firing the corresponding projectile based on the coins consumed.