### PR TITLE
Perf: cache texture requests in Draw + remove trail allocation (sample)

### DIFF
--- a/NPCs/DevourerofGods/DevourerofGodsBody.cs
+++ b/NPCs/DevourerofGods/DevourerofGodsBody.cs
@@ -19,6 +19,7 @@ namespace CalamityMod.NPCs.DevourerofGods
     [LongDistanceNetSync(SyncWith = typeof(DevourerofGodsHead))]
     public class DevourerofGodsBody : ModNPC
     {
+        private static Asset<Texture2D> _cachedTexHarshNoise;
         public static int phase2IconIndex;
 
         public override void Load()
@@ -296,7 +297,7 @@ namespace CalamityMod.NPCs.DevourerofGods
                 Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.NonPremultiplied, SamplerState.LinearWrap, DepthStencilState.Default, RasterizerState.CullNone, null, Main.GameViewMatrix.ZoomMatrix);
 
                 MiscShaderData dissolveShader = GameShaders.Misc["CalamityMod:Dissolve"];
-                Texture2D dissolveTexture = ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleGradients/HarshNoise").Value;
+                Texture2D dissolveTexture = (_cachedTexHarshNoise ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleGradients/HarshNoise")).Value;
 
                 dissolveShader.Shader.Parameters["noiseScale"].SetValue(0.25f);
                 dissolveShader.Shader.Parameters["dissolveIntensity"].SetValue(CalamityDrawParameterNPC.DoGDeathAnimationTimer / 600f);

--- a/NPCs/Providence/Providence.cs
+++ b/NPCs/Providence/Providence.cs
@@ -56,6 +56,12 @@ namespace CalamityMod.NPCs.Providence
     [AutoloadBossHead]
     public class Providence : ModNPC
     {
+        private static Asset<Texture2D> _cachedTexBloomCircle;
+        private static Asset<Texture2D> _cachedTexStarProj;
+        private static Asset<Texture2D> _cachedTexGreyscaleOpenCircleButBigger;
+        private static Asset<Texture2D> _cachedTexNeurons2;
+        private static Asset<Texture2D> _cachedTexProvidenceDeathSilhouette;
+
         private enum Phase : sbyte
         {
             PhaseChange = -1,
@@ -2127,7 +2133,7 @@ namespace CalamityMod.NPCs.Providence
                 // Okay it should also appear in Boss Rush as well
                 if (spawnAnimation && (NPC.localAI[1] == (float)BossMode.Normal || BossRushEvent.BossRushActive))
                 {
-                    Asset<Texture2D> orbTex = ModContent.Request<Texture2D>("CalamityMod/Particles/BloomCircle");
+                    Asset<Texture2D> orbTex = (_cachedTexBloomCircle ??= ModContent.Request<Texture2D>("CalamityMod/Particles/BloomCircle"));
                     float sc = CalamityUtils.CircInEasing((float)NPC.Calamity().newAI[3] / (float)spawnAnimationTime, 1);
 
                     for (int i = 0; i < 3; i++)
@@ -2329,7 +2335,7 @@ namespace CalamityMod.NPCs.Providence
             if (NPC.localAI[0] > 0f && NPC.localAI[0] < TimeForStarDespawn)
             {
                 float lerpMult = MathHelper.Lerp(0.5f, 1.5f, (float)Math.Sin(Main.GlobalTimeWrappedHourly * MathHelper.TwoPi) / 2f + 1f);
-                Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/Projectiles/StarProj").Value;
+                Texture2D tex = (_cachedTexStarProj ??= ModContent.Request<Texture2D>("CalamityMod/Projectiles/StarProj")).Value;
                 float drawOffsetAmt = (AIState == (int)Phase.FlameCocoon || AIState == (int)Phase.SpearCocoon) ? 20f : 64f;
                 Vector2 drawPos = NPC.Center + Vector2.UnitY * drawOffsetAmt * NPC.scale - Main.screenPosition;
                 Color baseColor = Color.Lerp(Color.Yellow, Color.OrangeRed, (float)Math.Sin(Main.GlobalTimeWrappedHourly) / 2f + 1f);
@@ -2380,7 +2386,7 @@ namespace CalamityMod.NPCs.Providence
                 float invertedSmallerOscillationRatio = 1f - (1f - smallerRemappedOscillation) * (1f - smallerRemappedOscillation);
                 float smallerOscillationScale = 1f - (1f - invertedSmallerOscillationRatio) * (1f - invertedSmallerOscillationRatio);
                 float shieldScale2 = (minScale + maxPulseScale * smallerOscillationScale) * invertedOscillationUsedForScale;
-                Texture2D shieldTexture = ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleOpenCircleButBigger").Value;
+                Texture2D shieldTexture = (_cachedTexGreyscaleOpenCircleButBigger ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleOpenCircleButBigger")).Value;
                 Rectangle shieldFrame = shieldTexture.Frame();
                 Vector2 origin = shieldFrame.Size() * 0.5f;
                 Vector2 shieldDrawPos = NPC.Center - screenPos;
@@ -2429,7 +2435,7 @@ namespace CalamityMod.NPCs.Providence
                 {
                     Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Additive, SamplerState.PointClamp, DepthStencilState.None, Main.Rasterizer, shieldEffect, matrix);
                     // Fetch shield heat overlay texture (this is the neutrons fed to the shader)
-                    Texture2D heatTex = ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleGradients/Neurons2").Value;
+                    Texture2D heatTex = (_cachedTexNeurons2 ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/GreyscaleGradients/Neurons2")).Value;
                     Vector2 pos = NPC.Center + NPC.gfxOffY * Vector2.UnitY - Main.screenPosition;
                     Main.spriteBatch.Draw(heatTex, shieldDrawPos, null, Color.White, 0, heatTex.Size() / 2f, shieldScale * scaleMult * 0.5f, 0, 0);
                     Main.spriteBatch.End();
@@ -2445,7 +2451,7 @@ namespace CalamityMod.NPCs.Providence
 
         public override void PostDraw(SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
         {
-            Texture2D tex = ModContent.Request<Texture2D>("CalamityMod/NPCs/Providence/Providence_DeathSilhouette").Value;
+            Texture2D tex = (_cachedTexProvidenceDeathSilhouette ??= ModContent.Request<Texture2D>("CalamityMod/NPCs/Providence/Providence_DeathSilhouette")).Value;
 
             if (Dying)
             {

--- a/Projectiles/Boss/HolyBlastFrags.cs
+++ b/Projectiles/Boss/HolyBlastFrags.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ReLogic.Content;
+using System;
 using System.Linq;
 using CalamityMod.Graphics.Primitives;
 using CalamityMod.NPCs.Providence;
@@ -18,6 +19,9 @@ namespace CalamityMod.Projectiles.Boss
 {
     public class HolyBlastFrags : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexScarletDevilStreak;
+        private static Asset<Texture2D> _cachedTexHolyFire2Night;
+
         public override string Texture => "CalamityMod/Projectiles/Boss/HolyFire2";
 
         public new string LocalizationCategory => "Projectiles.Boss";
@@ -104,7 +108,7 @@ namespace CalamityMod.Projectiles.Boss
 
                 list.Insert(0, Projectile.position + (Projectile.rotation+MathHelper.PiOver2 * Projectile.spriteDirection).ToRotationVector2() * 16f);
 
-                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak"));
+                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexScarletDevilStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak")));
                 PrimitiveRenderer.RenderTrail(list.ToArray(), new(FireWidthFunction, FireColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), Projectile.oldPos.Length + 32);
             }
 
@@ -113,7 +117,7 @@ namespace CalamityMod.Projectiles.Boss
             Main.spriteBatch.End();
 
             Main.spriteBatch.Begin(ss);
-            Texture2D texture = ProvUtils.StandardAI() ? Terraria.GameContent.TextureAssets.Projectile[Type].Value : ModContent.Request<Texture2D>("CalamityMod/Projectiles/Boss/HolyFire2Night").Value;
+            Texture2D texture = ProvUtils.StandardAI() ? Terraria.GameContent.TextureAssets.Projectile[Type].Value : (_cachedTexHolyFire2Night ??= ModContent.Request<Texture2D>("CalamityMod/Projectiles/Boss/HolyFire2Night")).Value;
             int framing = texture.Height / Main.projFrames[Type];
             int y6 = framing * Projectile.frame;
             Projectile.DrawBackglow(ProvUtils.GetProjectileColor(lightColor, true), 4f, texture);
@@ -125,8 +129,6 @@ namespace CalamityMod.Projectiles.Boss
             float width;
             float maxBodyWidth = 38f * Projectile.scale;
             float curveRatio = 0.2f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
             // Crop the tip of the trail into a conic shape.
             if (completion < curveRatio)
                 width = MathF.Pow(completion / curveRatio, 0.5f) * maxBodyWidth;
@@ -136,7 +138,7 @@ namespace CalamityMod.Projectiles.Boss
             // Pulse inwards and outwards over time.
             float pulseInterpolant = MathF.Cos(MathHelper.Pi * completion - Main.GlobalTimeWrappedHourly * 20f) * 0.5f + 0.5f;
             float additionalPulseWidth = MathHelper.Lerp(0f, 12f, pulseInterpolant);
-            return (width + additionalPulseWidth) * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type];
+            return (width + additionalPulseWidth) * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type];
         }
 
         public Color FireColorFunction(float completion, Vector2 pos)

--- a/Projectiles/Magic/AlphaDraconisStar.cs
+++ b/Projectiles/Magic/AlphaDraconisStar.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ReLogic.Content;
+using System;
 using System.Linq;
 using CalamityMod.Buffs.DamageOverTime;
 using CalamityMod.Dusts;
@@ -19,6 +20,9 @@ namespace CalamityMod.Projectiles.Magic
 {
     public class AlphaDraconisStar : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexScarletDevilStreak;
+        private static Asset<Texture2D> _cachedTexSylvestaffStreak;
+
         public new string LocalizationCategory => "Projectiles.Magic";
         public override void SetStaticDefaults()
         {
@@ -216,11 +220,11 @@ namespace CalamityMod.Projectiles.Magic
             {
                 if (Projectile.velocity.Length() > 1) // Will otherwise cause noticeable frame drops
                 {
-                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak"));
+                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexScarletDevilStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak")));
                     PrimitiveRenderer.RenderTrail(Projectile.oldPos, new(FireWidthFunction, FireColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), Projectile.oldPos.Length + 32);
 
                     Vector2[] fireCoreLength = Projectile.oldPos.Take(8).ToArray();
-                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/SylvestaffStreak"));
+                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexSylvestaffStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/SylvestaffStreak")));
                     PrimitiveRenderer.RenderTrail(fireCoreLength, new(FireCoreWidthFunction, FireCoreColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), fireCoreLength.Length + 24);
                 }
             }
@@ -238,8 +242,6 @@ namespace CalamityMod.Projectiles.Magic
             float width;
             float maxBodyWidth = 32f * Projectile.scale;
             float curveRatio = 0.05f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
             // Crop the tip of the trail into a conic shape.
             if (completion < curveRatio)
                 width = MathF.Pow(completion / curveRatio, 0.5f) * maxBodyWidth;
@@ -249,7 +251,7 @@ namespace CalamityMod.Projectiles.Magic
             // Pulse inwards and outwards over time.
             float pulseInterpolant = MathF.Cos(MathHelper.Pi * completion - Main.GlobalTimeWrappedHourly * 20f) * 0.5f + 0.5f;
             float additionalPulseWidth = MathHelper.Lerp(0f, 12f, pulseInterpolant);
-            return (width + additionalPulseWidth) * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type];
+            return (width + additionalPulseWidth) * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type];
         }
 
         public Color FireColorFunction(float completion, Vector2 pos)
@@ -264,14 +266,11 @@ namespace CalamityMod.Projectiles.Magic
             float width;
             float maxBodyWidth = Projectile.scale * 8;
             float curveRatio = 0.1f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
-
             if (completion < curveRatio)
                 width = MathF.Sin(completion / curveRatio * MathHelper.PiOver2) * maxBodyWidth + curveRatio;
             else
                 width = Utils.Remap(completion, curveRatio, 1f, maxBodyWidth, 0f);
-            return width * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type];
+            return width * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type];
         }
 
         public Color FireCoreColorFunction(float completion, Vector2 pos)

--- a/Projectiles/Melee/AbyssBladeProjectile.cs
+++ b/Projectiles/Melee/AbyssBladeProjectile.cs
@@ -16,6 +16,9 @@ namespace CalamityMod.Projectiles.Melee
 {
     public class AbyssBladeProjectile : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexCircularSmearSmokey;
+        private static Asset<Texture2D> _cachedTexSemiCircularSmearSwipe;
+
         public new string LocalizationCategory => "Projectiles.Melee";
         public override string Texture => "CalamityMod/Items/Weapons/Melee/AbyssBlade";
 
@@ -242,8 +245,8 @@ namespace CalamityMod.Projectiles.Melee
         }
         public override bool PreDraw(ref Color lightColor)
         {
-            Asset<Texture2D> p = ModContent.Request<Texture2D>("CalamityMod/Particles/CircularSmearSmokey");
-            Asset<Texture2D> p2 = ModContent.Request<Texture2D>("CalamityMod/Particles/SemiCircularSmearSwipe");
+            Asset<Texture2D> p = (_cachedTexCircularSmearSmokey ??= ModContent.Request<Texture2D>("CalamityMod/Particles/CircularSmearSmokey"));
+            Asset<Texture2D> p2 = (_cachedTexSemiCircularSmearSwipe ??= ModContent.Request<Texture2D>("CalamityMod/Particles/SemiCircularSmearSwipe"));
             Vector2 generalDrawPos = Projectile.Center - Main.screenPosition;
             if (spinMode && Time < 9000)
             {

--- a/Projectiles/Melee/BalefulHarvesterHoldout.cs
+++ b/Projectiles/Melee/BalefulHarvesterHoldout.cs
@@ -16,6 +16,10 @@ namespace CalamityMod.Projectiles.Melee
 {
     public class BalefulHarvesterHoldout : BaseCustomUseStyleProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexSemiCircularSmearSwipe;
+        private static Asset<Texture2D> _cachedTexBloomCircle;
+        private static Asset<Texture2D> _cachedTexFullStar;
+
         public override int AssignedItemID => ModContent.ItemType<BalefulHarvester>();
         public override LocalizedText DisplayName => CalamityUtils.GetItemName<BalefulHarvester>();
         public override string Texture => "CalamityMod/Items/Weapons/Melee/BalefulHarvester";
@@ -218,7 +222,7 @@ namespace CalamityMod.Projectiles.Melee
             {
                 Asset<Texture2D> vanillaSmear = TextureAssets.Projectile[997];
                 Rectangle vanillaSmearFrame = vanillaSmear.Frame(1, 4, 0, 0);
-                Asset<Texture2D> smear = ModContent.Request<Texture2D>("CalamityMod/Particles/SemiCircularSmearSwipe");
+                Asset<Texture2D> smear = (_cachedTexSemiCircularSmearSwipe ??= ModContent.Request<Texture2D>("CalamityMod/Particles/SemiCircularSmearSwipe"));
                 float smearOpacity = CalamityUtils.Convert01To010(time / timeMax);
                 Main.EntitySpriteDraw(vanillaSmear.Value, Projectile.Center - Main.screenPosition, vanillaSmearFrame, new Color(193, 83, 43) * smearOpacity * 0.75f, FinalRotation - MathHelper.PiOver2, vanillaSmearFrame.Size() / 2f, 1.25f * Projectile.scale, SpriteEffects.None);
                 Main.EntitySpriteDraw(smear.Value, Projectile.Center - Main.screenPosition, null, new Color(247, 115, 0) * smearOpacity, FinalRotation, smear.Size() / 2f, 1.8f * Projectile.scale, SpriteEffects.None);
@@ -226,9 +230,9 @@ namespace CalamityMod.Projectiles.Melee
                 if (smearOpacity > 0.65f)
                 {
                     Vector2 sparklePos = Projectile.Center - Main.screenPosition - (Vector2.UnitY.RotatedBy(FinalRotation + MathHelper.PiOver4 * Owner.direction) * 120f);
-                    Asset<Texture2D> bloom = ModContent.Request<Texture2D>("CalamityMod/Particles/BloomCircle");
+                    Asset<Texture2D> bloom = (_cachedTexBloomCircle ??= ModContent.Request<Texture2D>("CalamityMod/Particles/BloomCircle"));
                     Main.EntitySpriteDraw(bloom.Value, sparklePos, null, Color.White * 0.75f, 0f, bloom.Size() / 2f, 0.2f * Projectile.scale, SpriteEffects.None);
-                    Asset<Texture2D> sparkle = ModContent.Request<Texture2D>("CalamityMod/Particles/FullStar");
+                    Asset<Texture2D> sparkle = (_cachedTexFullStar ??= ModContent.Request<Texture2D>("CalamityMod/Particles/FullStar"));
                     Main.EntitySpriteDraw(sparkle.Value, sparklePos, null, Color.Orange, 0f, sparkle.Size() / 2f, 2f * Projectile.scale, SpriteEffects.None);
                 }
             }

--- a/Projectiles/Melee/CometQuasherMeteor.cs
+++ b/Projectiles/Melee/CometQuasherMeteor.cs
@@ -1,6 +1,7 @@
 ﻿using CalamityMod.Particles;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
@@ -10,6 +11,9 @@ namespace CalamityMod.Projectiles.Melee
 {
     public class CometQuasherMeteor : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexCometQuasherMeteor2;
+        private static Asset<Texture2D> _cachedTexCometQuasherMeteor3;
+
         public new string LocalizationCategory => "Projectiles.Melee";
         public ref float time => ref Projectile.ai[0];
         public Color mainColor = Color.DodgerBlue;
@@ -92,10 +96,10 @@ namespace CalamityMod.Projectiles.Melee
                     tex = Terraria.GameContent.TextureAssets.Projectile[Type].Value;
                     break;
                 case 1:
-                    tex = ModContent.Request<Texture2D>("CalamityMod/Projectiles/Melee/CometQuasherMeteor2").Value;
+                    tex = (_cachedTexCometQuasherMeteor2 ??= ModContent.Request<Texture2D>("CalamityMod/Projectiles/Melee/CometQuasherMeteor2")).Value;
                     break;
                 case 2:
-                    tex = ModContent.Request<Texture2D>("CalamityMod/Projectiles/Melee/CometQuasherMeteor3").Value;
+                    tex = (_cachedTexCometQuasherMeteor3 ??= ModContent.Request<Texture2D>("CalamityMod/Projectiles/Melee/CometQuasherMeteor3")).Value;
                     break;
             }
 

--- a/Projectiles/Rogue/ProfanedPartisanFlare.cs
+++ b/Projectiles/Rogue/ProfanedPartisanFlare.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ReLogic.Content;
+using System;
 using System.Linq;
 using CalamityMod.Buffs.DamageOverTime;
 using CalamityMod.Graphics.Primitives;
@@ -19,6 +20,9 @@ namespace CalamityMod.Projectiles.Rogue
 {
     public class ProfanedPartisanFlare : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexScarletDevilStreak;
+        private static Asset<Texture2D> _cachedTexGlowOrbParticle;
+
         public new string LocalizationCategory => "Projectiles.Rogue";
         public int timer = 0;
         public override string Texture => "CalamityMod/Projectiles/Boss/HolyFire";
@@ -125,7 +129,7 @@ namespace CalamityMod.Projectiles.Rogue
             {
                 using (trailLease.Scope(clearColor: Color.Transparent))
                 {
-                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak"));
+                    GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexScarletDevilStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak")));
                     PrimitiveRenderer.RenderTrail(Projectile.oldPos.Take(5).ToArray(), new(FireWidthFunction, FireColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), Projectile.oldPos.Length + 32);
                 }
 
@@ -165,7 +169,7 @@ namespace CalamityMod.Projectiles.Rogue
                 Main.EntitySpriteDraw(texture, drawPos, null, baseColor2, left - Projectile.rotation, origin, scale * 0.36f, spriteEffects, 0);
 
                 scale = new Vector2(1f, 1f);
-                texture = ModContent.Request<Texture2D>("CalamityMod/Particles/GlowOrbParticle").Value;
+                texture = (_cachedTexGlowOrbParticle ??= ModContent.Request<Texture2D>("CalamityMod/Particles/GlowOrbParticle")).Value;
                 using (Main.spriteBatch.Scope())
                 {
 
@@ -188,8 +192,6 @@ namespace CalamityMod.Projectiles.Rogue
             float width;
             float maxBodyWidth = 16f * Projectile.scale;
             float curveRatio = 0.2f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
             // Crop the tip of the trail into a conic shape.
             if (completion < curveRatio)
                 width = MathF.Pow(completion / curveRatio, 0.5f) * maxBodyWidth;
@@ -199,7 +201,7 @@ namespace CalamityMod.Projectiles.Rogue
             // Pulse inwards and outwards over time.
             float pulseInterpolant = MathF.Cos(MathHelper.Pi * completion - Main.GlobalTimeWrappedHourly * 20f) * 0.5f + 0.5f;
             float additionalPulseWidth = MathHelper.Lerp(0f, 12f, pulseInterpolant);
-            return (width + additionalPulseWidth) * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type];
+            return (width + additionalPulseWidth) * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type];
         }
 
         public Color FireColorFunction(float completion, Vector2 pos)

--- a/Projectiles/Summon/SiriusBeam.cs
+++ b/Projectiles/Summon/SiriusBeam.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ReLogic.Content;
+using System;
 using System.Linq;
 using CalamityMod.Buffs.DamageOverTime;
 using CalamityMod.Graphics.Primitives;
@@ -17,6 +18,9 @@ namespace CalamityMod.Projectiles.Summon
 {
     public class SiriusBeam : ModProjectile, ILocalizedModType
     {
+        private static Asset<Texture2D> _cachedTexScarletDevilStreak;
+        private static Asset<Texture2D> _cachedTexSylvestaffStreak;
+
         public new string LocalizationCategory => "Projectiles.Summon";
         public override string Texture => "CalamityMod/Projectiles/InvisibleProj";
 
@@ -96,11 +100,11 @@ namespace CalamityMod.Projectiles.Summon
 
             using (lease.Scope(clearColor: Color.Transparent))
             {
-                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak"));
+                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexScarletDevilStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/ScarletDevilStreak")));
                 PrimitiveRenderer.RenderTrail(Projectile.oldPos, new(FireWidthFunction, FireColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), Projectile.oldPos.Length + 32);
 
                 Vector2[] fireCoreLength = Projectile.oldPos.Take(8).ToArray();
-                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture(ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/SylvestaffStreak"));
+                GameShaders.Misc["CalamityMod:ImpFlameTrail"].SetShaderTexture((_cachedTexSylvestaffStreak ??= ModContent.Request<Texture2D>("CalamityMod/ExtraTextures/Trails/SylvestaffStreak")));
                 PrimitiveRenderer.RenderTrail(fireCoreLength, new(FireCoreWidthFunction, FireCoreColorFunction, (_, _) => Projectile.Size * 0.5f, smoothen: true, pixelate: false, shader: GameShaders.Misc["CalamityMod:ImpFlameTrail"], useUnscaledMatrices: true), fireCoreLength.Length + 24);
             }
 
@@ -118,8 +122,6 @@ namespace CalamityMod.Projectiles.Summon
             float width;
             float maxBodyWidth = 38f * Projectile.scale;
             float curveRatio = 0.2f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
             // Crop the tip of the trail into a conic shape.
             if (completion < curveRatio)
                 width = MathF.Pow(completion / curveRatio, 0.5f) * maxBodyWidth;
@@ -129,7 +131,7 @@ namespace CalamityMod.Projectiles.Summon
             // Pulse inwards and outwards over time.
             float pulseInterpolant = MathF.Cos(MathHelper.Pi * completion - Main.GlobalTimeWrappedHourly * 20f) * 0.5f + 0.5f;
             float additionalPulseWidth = MathHelper.Lerp(0f, 12f, pulseInterpolant);
-            return  (width + additionalPulseWidth ) * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type] ;
+            return  (width + additionalPulseWidth ) * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type] ;
         }
 
         public Color FireColorFunction(float completion, Vector2 pos)
@@ -144,14 +146,11 @@ namespace CalamityMod.Projectiles.Summon
             float width;
             float maxBodyWidth = Projectile.scale * 16;
             float curveRatio = 0.25f;
-            var positions = Projectile.oldPos.ToList();
-            positions.RemoveAll(x => x == Vector2.Zero);
-
             if (completion < curveRatio)
                 width = MathF.Sin(completion / curveRatio * MathHelper.PiOver2) * maxBodyWidth + curveRatio;
             else
                 width = Utils.Remap(completion, curveRatio, 1f, maxBodyWidth, 0f);
-            return  width * positions.Count() / (float)ProjectileID.Sets.TrailCacheLength[Type];
+            return  width * CalamityUtils.CountNonZeroVectors(Projectile.oldPos) / (float)ProjectileID.Sets.TrailCacheLength[Type];
         }
 
         public Color FireCoreColorFunction(float completion, Vector2 pos)

--- a/Utilities/DrawingUtils.cs
+++ b/Utilities/DrawingUtils.cs
@@ -18,6 +18,18 @@ namespace CalamityMod
 {
     public static partial class CalamityUtils
     {
+        // Counts non-Vector2.Zero entries without allocating, for use with Projectile.oldPos-style trail arrays.
+        public static int CountNonZeroVectors(Vector2[] positions)
+        {
+            int count = 0;
+            for (int i = 0; i < positions.Length; i++)
+            {
+                if (positions[i] != Vector2.Zero)
+                    count++;
+            }
+            return count;
+        }
+
         internal static Texture2D AuroraTexture
         {
             get


### PR DESCRIPTION
Sample covering 10 files out of a larger automated pass:

1. Cache ModContent.Request<Texture2D> calls that use a literal string path inside PreDraw/PostDraw in a static field (populated once via ??=), instead of repeating the asset-repository lookup every render frame.

2. Replace the repeated `Projectile.oldPos.ToList(); positions.RemoveAll(x => x == Vector2.Zero);` idiom (used only for its .Count() afterwards) with a new zero-allocation CalamityUtils.CountNonZeroVectors helper.

Produced with a small Roslyn-based source tool (conservative: only literal-argument call sites, partial classes skipped, every output re-parsed to confirm no syntax errors introduced).